### PR TITLE
Implement kernel layout and direct mapping

### DIFF
--- a/src/kernel/include/mm/heap_utils.h
+++ b/src/kernel/include/mm/heap_utils.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include <lib/types.h>
+#include <mm/kernel_layout.h>
+
+/**
+ * @file mm/heap_utils.h
+ * @brief Utility per la gestione della memoria heap del kernel
+ *
+ * Queste funzioni forniscono un layer minimo per riservare e mappare
+ * pagine nell'area dedicata all'heap del kernel. L'allocatore vero e
+ * proprio potrà costruirsi sopra queste primitive.
+ */
+
+/**
+ * @brief Riserva un range virtuale contiguo nell'area heap
+ *
+ * La dimensione deve essere multipla di PAGE_SIZE. Nessuna pagina fisica
+ * viene mappata in questa fase.
+ *
+ * @param size Dimensione richiesta in byte
+ * @return Indirizzo virtuale base riservato oppure NULL se non c'è spazio
+ */
+void *heap_reserve_virtual_range(size_t size);
+
+/**
+ * @brief Libera un range virtuale precedentemente riservato
+ *
+ * Attualmente è un segnaposto per future estensioni. Non effettua alcuna
+ * operazione reale.
+ */
+void heap_release_virtual_range(void *base, size_t size);
+
+/**
+ * @brief Mappa pagine fisiche all'interno di un range virtuale dell'heap
+ *
+ * @param virt_base Indirizzo virtuale dove iniziare la mappatura
+ * @param page_count Numero di pagine consecutive da mappare
+ * @return true se la mappatura è riuscita
+ */
+bool heap_map_physical_pages(void *virt_base, size_t page_count);
+
+/**
+ * @brief Rimuove la mappatura fisica da un range virtuale dell'heap
+ *
+ * Il range virtuale rimane riservato ma le pagine fisiche vengono liberate.
+ */
+void heap_unmap_physical_pages(void *virt_base, size_t page_count);
+
+/**
+ * @brief Verifica se un indirizzo ricade nell'area heap del kernel
+ */
+bool heap_address_valid(const void *addr);

--- a/src/kernel/include/mm/kernel_layout.h
+++ b/src/kernel/include/mm/kernel_layout.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <arch/memory.h>
+
+/**
+ * @file mm/kernel_layout.h
+ * @brief Definizioni del layout di memoria virtuale del kernel
+ *
+ * Questo header raccoglie gli indirizzi base e le dimensioni delle
+ * principali aree dello spazio virtuale del kernel. Tutti i valori sono
+ * canonici per l'architettura x86_64 a 64 bit e devono rimanere
+ * sincronizzati con lo script di linker.
+ */
+
+/* -------------------------------------------------------------------------- */
+/*                               REGIONI BASE                                 */
+/* -------------------------------------------------------------------------- */
+
+/** Indirizzo virtuale di partenza dell'immagine del kernel */
+#define KERNEL_TEXT_BASE 0xFFFFFFFF80000000UL
+
+/** Base dell'area di direct mapping (fisico->virtuale) */
+#define DIRECT_MAP_BASE  0xFFFF800000000000UL
+/** Dimensione massima mappata dal direct mapping */
+#define DIRECT_MAP_SIZE  (64UL * GB)
+
+/** Base del kernel heap (allocazioni dinamiche) */
+#define KERNEL_HEAP_BASE 0xFFFF888000000000UL
+/** Dimensione complessiva riservata per l'heap */
+#define KERNEL_HEAP_SIZE (16UL * GB)
+
+/** Base dell'area vmalloc per mapping dinamici di driver/moduli */
+#define VMALLOC_BASE     0xFFFFC88000000000UL
+/** Dimensione riservata all'area vmalloc */
+#define VMALLOC_SIZE     (16UL * GB)
+
+/* -------------------------------------------------------------------------- */
+/*                              MACRO UTILITARIE                              */
+/* -------------------------------------------------------------------------- */
+
+/** Converte un indirizzo fisico in virtuale nel direct mapping */
+#define PHYS_TO_VIRT(addr) ((u64)(addr) + DIRECT_MAP_BASE)
+/** Converte un indirizzo virtuale del direct mapping in fisico */
+#define VIRT_TO_PHYS(addr) ((u64)(addr) - DIRECT_MAP_BASE)
+
+/** Verifica se un indirizzo appartiene all'area heap del kernel */
+#define IS_KERNEL_HEAP(addr)  \
+    ((u64)(addr) >= KERNEL_HEAP_BASE &&
+     (u64)(addr) < (KERNEL_HEAP_BASE + KERNEL_HEAP_SIZE))
+

--- a/src/kernel/include/mm/vmm.h
+++ b/src/kernel/include/mm/vmm.h
@@ -2,6 +2,7 @@
 
 #include <arch/memory.h>
 #include <lib/types.h>
+#include <mm/kernel_layout.h>
 
 /* -------------------------------------------------------------------------- */
 /*                         VMM CONFIGURATION CONSTANTS                        */

--- a/src/kernel/mm/heap_utils.c
+++ b/src/kernel/mm/heap_utils.c
@@ -1,0 +1,87 @@
+#include <mm/heap_utils.h>
+#include <mm/pmm.h>
+#include <mm/vmm.h>
+#include <klib/klog.h>
+
+/*
+ * ===========================================================================
+ * HEAP UTILS - SUPPORTO BASICO PER L'HEAP DEL KERNEL
+ * ===========================================================================
+ *
+ * Queste funzioni offrono meccanismi elementari per gestire lo spazio
+ * virtuale dedicato all'heap del kernel. Non implementano un vero
+ * allocatore: forniscono solo la riserva dell'area virtuale e la mappatura
+ * di pagine fisiche tramite il PMM/VMM.
+ */
+
+/* Puntatore alla prossima area virtuale disponibile nell'heap */
+static u64 next_heap_virtual = KERNEL_HEAP_BASE;
+
+/**
+ * @brief Riserva un range virtuale per l'heap
+ *
+ * Nessuna pagina fisica viene allocata: semplicemente si avanza il
+ * puntatore next_heap_virtual all'interno della zona heap.
+ */
+void *heap_reserve_virtual_range(size_t size) {
+    size = PAGE_ALIGN_UP(size);
+    if (next_heap_virtual + size > KERNEL_HEAP_BASE + KERNEL_HEAP_SIZE) {
+        klog_error("heap_utils: Spazio heap virtuale esaurito");
+        return NULL;
+    }
+    void *res = (void *)next_heap_virtual;
+    next_heap_virtual += size;
+    klog_debug("heap_utils: Riservato range virtuale 0x%lx - 0x%lx (%zu KB)",
+               (u64)res, (u64)res + size, size / 1024);
+    return res;
+}
+
+/**
+ * @brief Placeholder per la futura liberazione di range virtuali
+ */
+void heap_release_virtual_range(void *base, size_t size) {
+    (void)base;
+    (void)size;
+}
+
+/**
+ * @brief Mappa pagine fisiche in un range virtuale dell'heap
+ */
+bool heap_map_physical_pages(void *virt_base, size_t page_count) {
+    if (!heap_address_valid(virt_base)) {
+        return false;
+    }
+    u64 virt_addr = (u64)virt_base;
+    void *phys_pages = pmm_alloc_pages(page_count);
+    if (!phys_pages) {
+        klog_error("heap_utils: PMM allocation failed for %zu pages", page_count);
+        return false;
+    }
+    u64 flags = VMM_FLAG_READ | VMM_FLAG_WRITE | VMM_FLAG_GLOBAL;
+    if (!vmm_map(vmm_kernel_space(), virt_addr, (u64)phys_pages, page_count, flags)) {
+        klog_error("heap_utils: VMM mapping failed");
+        pmm_free_pages(phys_pages, page_count);
+        return false;
+    }
+    klog_debug("heap_utils: Mapped %zu pages: virt=0x%lx -> phys=0x%lx",
+               page_count, virt_addr, (u64)phys_pages);
+    return true;
+}
+
+/**
+ * @brief Rimuove i mapping fisici da un range dell'heap
+ */
+void heap_unmap_physical_pages(void *virt_base, size_t page_count) {
+    if (!heap_address_valid(virt_base)) {
+        return;
+    }
+    vmm_unmap(vmm_kernel_space(), (u64)virt_base, page_count);
+}
+
+/**
+ * @brief Controlla se un indirizzo rientra nella zona heap
+ */
+bool heap_address_valid(const void *addr) {
+    u64 a = (u64)addr;
+    return IS_KERNEL_HEAP(a);
+}


### PR DESCRIPTION
## Summary
- add kernel memory layout header
- add heap utility stubs
- implement direct mapping in x86_64 VMM
- adjust VMM to use direct map addresses
- validate layout and test mapping in `kmain`
- document new headers and utilities