### PR TITLE
Improve VMM debug features

### DIFF
--- a/src/kernel/Makefile
+++ b/src/kernel/Makefile
@@ -27,9 +27,14 @@ $(KERNEL_ELF): $(KERNEL_OBJECTS) $(LD_SCRIPT)
 	ld.lld -n -T $(LD_SCRIPT) -o $@ $(ARCH_OBJECTS) $(KERNEL_OBJECTS)
 
 # Compilazione C
+CFLAGS := -target x86_64-pc-none-elf -ffreestanding -nostdlib -nostdinc -mcmodel=kernel -DDEBUG -I./include
+ifdef VMM_BOOT_DEBUG
+CFLAGS += -DVMM_BOOT_DEBUG
+endif
+
 $(BUILD_DIR)/%.o: ./%.c
 	@mkdir -p $(dir $@)
-	clang -target x86_64-pc-none-elf -ffreestanding -nostdlib -nostdinc -mcmodel=kernel -DDEBUG -I./include -c $< -o $@
+	clang $(CFLAGS) -c $< -o $@
 
 # Compilazione ASM - .s
 $(BUILD_DIR)/%.o: ./%.s

--- a/src/kernel/main.c
+++ b/src/kernel/main.c
@@ -55,6 +55,11 @@ void kmain(void) {
   klog_info("Initializing Virtual Memory Manager...");
   vmm_init();
   klog_info("VMM initialized successfully");
+#ifdef VMM_BOOT_DEBUG
+  klog_info("Running VMM debug routines...");
+  vmm_debug_dump(NULL);
+  vmm_check_integrity(NULL);
+#endif
 
   /*
    * FASE 4: STATISTICHE FINALI

--- a/src/kernel/main.c
+++ b/src/kernel/main.c
@@ -50,11 +50,43 @@ void kmain(void) {
   }
 
   /*
+   * TEST PMM: ALLOCAZIONE E DEALLOCAZIONE
+   */
+  void *test_page1 = pmm_alloc_page();
+  void *test_block = pmm_alloc_pages(8);
+
+  if (test_page1 && test_block) {
+    klog_info("PMM test: allocated single page at %p", test_page1);
+    klog_info("PMM test: allocated 8-page block at %p", test_block);
+
+    pmm_free_page(test_page1);
+    klog_info("PMM test: successfully deallocated single page");
+
+    pmm_result_t partial = pmm_free_pages(test_block, 8);
+    if (partial != PMM_SUCCESS) {
+      klog_info("PMM test: partial free of 6 pages rejected as expected (code: %d)", partial);
+    } else {
+      klog_warn("PMM test: partial free unexpectedly succeeded!");
+    }
+
+    pmm_result_t full = pmm_free_pages(test_block, 8);
+    if (full == PMM_SUCCESS) {
+      klog_info("PMM test: full block deallocation succeeded");
+    } else {
+      klog_warn("PMM test: full block deallocation failed (code: %d)", full);
+    }
+
+  } else {
+    klog_warn("PMM test: failed to allocate test pages");
+  }
+
+  /*
    * FASE 3: INIZIALIZZAZIONE VIRTUAL MEMORY MANAGER
    */
   klog_info("Initializing Virtual Memory Manager...");
   vmm_init();
   klog_info("VMM initialized successfully");
+
 #ifdef VMM_BOOT_DEBUG
   klog_info("Running VMM debug routines...");
   vmm_debug_dump(NULL);
@@ -70,7 +102,7 @@ void kmain(void) {
   }
 
   /*
-   * FASE 6: MICROKERNEL READY
+   * FASE 5: MICROKERNEL READY
    */
   klog_info("=== MICROKERNEL INITIALIZATION COMPLETE ===");
   klog_info("All tests completed - ZONE-OS microkernel ready");


### PR DESCRIPTION
## Summary
- recursively dump page tables in `vmm_x86_64_debug_dump`
- tighten `vmm_x86_64_check_integrity` with alignment/permission checks
- optionally run debug dump at boot via `VMM_BOOT_DEBUG`
- allow enabling the boot debug option from the kernel makefile