### PR TITLE
Implement high-half kernel mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ make dev
 - [x] Output text basilare
 - [x] Build system automatizzata
 - [x] Hot-reload development
+- [x] High-half kernel mapping
 
 ### 🚧 In Sviluppo
 

--- a/docs/1.0 - Architettura generale del PMM.md
+++ b/docs/1.0 - Architettura generale del PMM.md
@@ -49,3 +49,7 @@ end
     style INIT fill:#e8f5e8
     style LMM fill:#fff3e0
 ```
+
+## High-half mapping
+
+Il Virtual Memory Manager mappa il kernel nella porzione alta dello spazio degli indirizzi (>= `0xFFFF800000000000`). Ogni nuovo spazio di indirizzamento eredita tali mappature per poter accedere alle strutture di kernel.


### PR DESCRIPTION
## Summary
- clone bootloader page tables and switch to them for the kernel
- inherit kernel mappings when creating new address spaces
- document high-half mapping in PMM docs
- list high-half mapping as a completed feature in README