### PR TITLE
Dynamic memory regions after heap init

### DIFF
--- a/src/kernel/include/mm/memory.h
+++ b/src/kernel/include/mm/memory.h
@@ -11,15 +11,18 @@
  * a tutto il kernel. Tutte le implementazioni dipendono dalle funzioni
  * arch-specifiche dichiarate in arch/memory.h.
  */
-#define MAX_REGIONS 512 // Limite massimo di regioni supportate nel kernel
-
-extern memory_region_t regions[];
+extern memory_region_t *regions;
 extern size_t region_count;
 
 /**
  * @brief Inizializza il sottosistema memoria (arch + logica)
  */
 void memory_init(void);
+
+/**
+ * @brief Completa l'inizializzazione dopo che lo heap è pronto
+ */
+void memory_late_init(void);
 
 /**
  * @brief Stampa a schermo la mappa memoria rilevata (debug)

--- a/src/kernel/main.c
+++ b/src/kernel/main.c
@@ -92,6 +92,7 @@ void kmain(void) {
    * FASE 5: TEST HEAP COMPLETI
    */
   heap_init();
+  memory_late_init();
 
   /*
    * FASE 6: STATISTICHE FINALI

--- a/src/kernel/mm/pmm.c
+++ b/src/kernel/mm/pmm.c
@@ -332,8 +332,8 @@ pmm_result_t pmm_init(void) {
    * Chiediamo al layer architetturale: "Dimmi che memoria abbiamo!"
    * Risposta: array di regioni con tipo, base, e dimensione.
    */
-  memory_region_t regions[MAX_REGIONS];
-  size_t region_count = arch_memory_detect_regions(regions, MAX_REGIONS);
+  memory_region_t regions[ARCH_MAX_MEMORY_REGIONS];
+  size_t region_count = arch_memory_detect_regions(regions, ARCH_MAX_MEMORY_REGIONS);
 
   if (region_count == 0) {
     klog_error("PMM: Il layer architetturale non ha trovato memoria!");


### PR DESCRIPTION
## Summary
- hold detected memory regions in a temporary static array
- allocate the final regions table with `kmalloc()` after heap initialization
- remove MAX_REGIONS and use architecture limit for temporary array
- update PMM accordingly