### PR TITLE
Implement basic interrupt handling

### DIFF
--- a/src/kernel/arch/x86_64/interrupts_arch.c
+++ b/src/kernel/arch/x86_64/interrupts_arch.c
@@ -1,96 +1,145 @@
-#include <arch/interrupts.h>
 #include <arch/cpu.h>
+#include <arch/interrupts.h>
 #include <arch/io.h>
 #include <klib/klog.h>
 
+/*
+ * ============================================================================
+ * IDT (Interrupt Descriptor Table) SETUP
+ * ============================================================================
+ */
+
 #define IDT_ENTRIES 256
+#define IRQ_COUNT 16
 #define IDT_FLAG_INT_GATE 0x8E
 #define KERNEL_CS 0x08
 
 typedef struct __attribute__((packed)) {
-    u16 offset_low;
-    u16 selector;
-    u8  ist;
-    u8  type_attr;
-    u16 offset_mid;
-    u32 offset_high;
-    u32 zero;
+  u16 offset_low;  // [0:15]   Bits bassi indirizzo ISR
+  u16 selector;    //         Segment selector (es. KERNEL_CS)
+  u8 ist;          //         Interrupt Stack Table (non usato)
+  u8 type_attr;    //         Tipo (interrupt gate) e flag
+  u16 offset_mid;  // [16:31]  Bits medi indirizzo ISR
+  u32 offset_high; // [32:63]  Bits alti indirizzo ISR
+  u32 zero;        //         Riservato
 } idt_entry_t;
 
 typedef struct __attribute__((packed)) {
-    u16 limit;
-    u64 base;
+  u16 limit;
+  u64 base;
 } idt_ptr_t;
 
 static idt_entry_t idt[IDT_ENTRIES];
 static idt_ptr_t idt_descriptor;
 
-extern void *isr_stub_table[];
-extern void isr_common_stub(void);
+extern void *isr_stub_table[];     // Tabella definita in isr_stub.s
+extern void isr_common_stub(void); // Stub assembly condiviso per gli ISR
 
+// Imposta una entry dell'IDT
 static void idt_set_gate(int n, void *isr, u8 flags) {
-    u64 addr = (u64)isr;
-    idt[n].offset_low = addr & 0xFFFF;
-    idt[n].selector = KERNEL_CS;
-    idt[n].ist = 0;
-    idt[n].type_attr = flags;
-    idt[n].offset_mid = (addr >> 16) & 0xFFFF;
-    idt[n].offset_high = (addr >> 32) & 0xFFFFFFFF;
-    idt[n].zero = 0;
+  u64 addr = (u64)isr;
+  idt[n].offset_low = addr & 0xFFFF;
+  idt[n].selector = KERNEL_CS;
+  idt[n].ist = 0;
+  idt[n].type_attr = flags;
+  idt[n].offset_mid = (addr >> 16) & 0xFFFF;
+  idt[n].offset_high = (addr >> 32) & 0xFFFFFFFF;
+  idt[n].zero = 0;
 }
 
+// Inizializza l’IDT con gli stub di interrupt
 void idt_init(void) {
-    idt_descriptor.limit = sizeof(idt) - 1;
-    idt_descriptor.base = (u64)&idt;
+  idt_descriptor.limit = sizeof(idt) - 1;
+  idt_descriptor.base = (u64)&idt;
 
-    for (int i = 0; i < 48; ++i) {
-        idt_set_gate(i, isr_stub_table[i], IDT_FLAG_INT_GATE);
-    }
+  for (int i = 0; i < 48; ++i) {
+    idt_set_gate(i, isr_stub_table[i], IDT_FLAG_INT_GATE);
+  }
 
-    __asm__ volatile("lidt %0" : : "m"(idt_descriptor));
-    klog_info("IDT initialized with %d entries", 48);
+  __asm__ volatile("lidt %0" : : "m"(idt_descriptor));
+  klog_info("IDT initialized with %d entries", 48);
 }
 
-/* -------------------------------- PIC ------------------------------------ */
-#define PIC1            0x20
-#define PIC2            0xA0
-#define PIC1_COMMAND    PIC1
-#define PIC1_DATA       (PIC1+1)
-#define PIC2_COMMAND    PIC2
-#define PIC2_DATA       (PIC2+1)
-#define PIC_EOI         0x20
+/*
+ * ============================================================================
+ * PIC (Programmable Interrupt Controller) SETUP
+ * ============================================================================
+ */
 
+#define PIC1 0x20
+#define PIC2 0xA0
+#define PIC1_COMMAND PIC1
+#define PIC1_DATA (PIC1 + 1)
+#define PIC2_COMMAND PIC2
+#define PIC2_DATA (PIC2 + 1)
+#define PIC_EOI 0x20
+
+// Remappa i vettori IRQ da [0-15] a [32-47]
 void pic_remap(u8 offset1, u8 offset2) {
-    u8 a1 = inb(PIC1_DATA);
-    u8 a2 = inb(PIC2_DATA);
+  u8 a1 = inb(PIC1_DATA); // Salva maschere attuali
+  u8 a2 = inb(PIC2_DATA);
 
-    outb(PIC1_COMMAND, 0x11);
-    outb(PIC2_COMMAND, 0x11);
+  outb(PIC1_COMMAND, 0x11); // Init
+  outb(PIC2_COMMAND, 0x11);
 
-    outb(PIC1_DATA, offset1);
-    outb(PIC2_DATA, offset2);
+  outb(PIC1_DATA, offset1); // Offset PIC1 = 0x20 (32)
+  outb(PIC2_DATA, offset2); // Offset PIC2 = 0x28 (40)
 
-    outb(PIC1_DATA, 4);
-    outb(PIC2_DATA, 2);
+  outb(PIC1_DATA, 4); // Informa che PIC2 è su IRQ2
+  outb(PIC2_DATA, 2);
 
-    outb(PIC1_DATA, 0x01);
-    outb(PIC2_DATA, 0x01);
+  outb(PIC1_DATA, 0x01); // Modalità 8086
+  outb(PIC2_DATA, 0x01);
 
-    outb(PIC1_DATA, a1);
-    outb(PIC2_DATA, a2);
+  outb(PIC1_DATA, a1); // Ripristina maschere originali
+  outb(PIC2_DATA, a2);
 }
 
+// Invia EOI (End Of Interrupt) al PIC dopo la gestione di un IRQ
 void pic_send_eoi(u8 irq) {
-    if (irq >= 8)
-        outb(PIC2_COMMAND, PIC_EOI);
-    outb(PIC1_COMMAND, PIC_EOI);
+  if (irq >= 8)
+    outb(PIC2_COMMAND, PIC_EOI);
+  outb(PIC1_COMMAND, PIC_EOI);
 }
 
-/* ----------------------------- ISR handler ------------------------------- */
-void isr_common_handler(isr_frame_t *frame) {
-    klog_warn("Interrupt vector %lu received", frame->int_no);
+/*
+ * ============================================================================
+ * IRQ HANDLER SYSTEM (Registrazione dinamica handler IRQ)
+ * ============================================================================
+ */
 
-    if (frame->int_no >= 32 && frame->int_no <= 47) {
-        pic_send_eoi(frame->int_no - 32);
+typedef void (*irq_handler_t)(isr_frame_t *);
+static irq_handler_t irq_handlers[IRQ_COUNT] = {0};
+
+// Permette al kernel di registrare un handler per un IRQ specifico
+void irq_register_handler(int irq, irq_handler_t handler) {
+  if (irq >= 0 && irq < IRQ_COUNT) {
+    irq_handlers[irq] = handler;
+    klog_info("IRQ %d handler registered", irq);
+  }
+}
+
+/*
+ * ============================================================================
+ * ISR COMMON HANDLER
+ * ============================================================================
+ */
+
+// Handler centrale chiamato da isr_common_stub (in ASM)
+void isr_common_handler(isr_frame_t *frame) {
+  u64 int_no = frame->int_no;
+
+  if (int_no >= 32 && int_no <= 47) {
+    int irq = int_no - 32;
+
+    if (irq_handlers[irq]) {
+      irq_handlers[irq](frame);
+    } else {
+      klog_warn("Unhandled IRQ %d", irq);
     }
+
+    pic_send_eoi(irq);
+  } else {
+    klog_warn("CPU Exception %lu occurred (not handled)", int_no);
+  }
 }

--- a/src/kernel/arch/x86_64/interrupts_arch.c
+++ b/src/kernel/arch/x86_64/interrupts_arch.c
@@ -1,0 +1,96 @@
+#include <arch/interrupts.h>
+#include <arch/cpu.h>
+#include <arch/io.h>
+#include <klib/klog.h>
+
+#define IDT_ENTRIES 256
+#define IDT_FLAG_INT_GATE 0x8E
+#define KERNEL_CS 0x08
+
+typedef struct __attribute__((packed)) {
+    u16 offset_low;
+    u16 selector;
+    u8  ist;
+    u8  type_attr;
+    u16 offset_mid;
+    u32 offset_high;
+    u32 zero;
+} idt_entry_t;
+
+typedef struct __attribute__((packed)) {
+    u16 limit;
+    u64 base;
+} idt_ptr_t;
+
+static idt_entry_t idt[IDT_ENTRIES];
+static idt_ptr_t idt_descriptor;
+
+extern void *isr_stub_table[];
+extern void isr_common_stub(void);
+
+static void idt_set_gate(int n, void *isr, u8 flags) {
+    u64 addr = (u64)isr;
+    idt[n].offset_low = addr & 0xFFFF;
+    idt[n].selector = KERNEL_CS;
+    idt[n].ist = 0;
+    idt[n].type_attr = flags;
+    idt[n].offset_mid = (addr >> 16) & 0xFFFF;
+    idt[n].offset_high = (addr >> 32) & 0xFFFFFFFF;
+    idt[n].zero = 0;
+}
+
+void idt_init(void) {
+    idt_descriptor.limit = sizeof(idt) - 1;
+    idt_descriptor.base = (u64)&idt;
+
+    for (int i = 0; i < 48; ++i) {
+        idt_set_gate(i, isr_stub_table[i], IDT_FLAG_INT_GATE);
+    }
+
+    __asm__ volatile("lidt %0" : : "m"(idt_descriptor));
+    klog_info("IDT initialized with %d entries", 48);
+}
+
+/* -------------------------------- PIC ------------------------------------ */
+#define PIC1            0x20
+#define PIC2            0xA0
+#define PIC1_COMMAND    PIC1
+#define PIC1_DATA       (PIC1+1)
+#define PIC2_COMMAND    PIC2
+#define PIC2_DATA       (PIC2+1)
+#define PIC_EOI         0x20
+
+void pic_remap(u8 offset1, u8 offset2) {
+    u8 a1 = inb(PIC1_DATA);
+    u8 a2 = inb(PIC2_DATA);
+
+    outb(PIC1_COMMAND, 0x11);
+    outb(PIC2_COMMAND, 0x11);
+
+    outb(PIC1_DATA, offset1);
+    outb(PIC2_DATA, offset2);
+
+    outb(PIC1_DATA, 4);
+    outb(PIC2_DATA, 2);
+
+    outb(PIC1_DATA, 0x01);
+    outb(PIC2_DATA, 0x01);
+
+    outb(PIC1_DATA, a1);
+    outb(PIC2_DATA, a2);
+}
+
+void pic_send_eoi(u8 irq) {
+    if (irq >= 8)
+        outb(PIC2_COMMAND, PIC_EOI);
+    outb(PIC1_COMMAND, PIC_EOI);
+}
+
+/* ----------------------------- ISR handler ------------------------------- */
+void isr_common_handler(isr_frame_t *frame) {
+    klog_warn("Interrupt vector %lu received", frame->int_no);
+
+    if (frame->int_no >= 32 && frame->int_no <= 47) {
+        pic_send_eoi(frame->int_no - 32);
+    }
+}

--- a/src/kernel/arch/x86_64/isr_stub.s
+++ b/src/kernel/arch/x86_64/isr_stub.s
@@ -1,0 +1,126 @@
+BITS 64
+section .text
+
+global isr_stub_table
+extern isr_common_stub
+extern isr_common_handler
+
+isr_stub_table:
+%assign i 0
+%rep 32
+    dq isr%+i
+%assign i i+1
+%endrep
+%assign j 0
+%rep 16
+    dq irq%+j
+%assign j j+1
+%endrep
+
+%macro ISR_NOERR 1
+isr%1:
+    push 0
+    push %1
+    jmp isr_common_stub
+%endmacro
+
+%macro ISR_ERR 1
+isr%1:
+    push %1
+    jmp isr_common_stub
+%endmacro
+
+%macro IRQ 2
+irq%2:
+    push 0
+    push %1
+    jmp isr_common_stub
+%endmacro
+
+ISR_NOERR 0
+ISR_NOERR 1
+ISR_NOERR 2
+ISR_NOERR 3
+ISR_NOERR 4
+ISR_NOERR 5
+ISR_NOERR 6
+ISR_NOERR 7
+ISR_ERR 8
+ISR_NOERR 9
+ISR_ERR 10
+ISR_ERR 11
+ISR_ERR 12
+ISR_ERR 13
+ISR_ERR 14
+ISR_NOERR 15
+ISR_NOERR 16
+ISR_ERR 17
+ISR_NOERR 18
+ISR_NOERR 19
+ISR_NOERR 20
+ISR_ERR 21
+ISR_NOERR 22
+ISR_NOERR 23
+ISR_NOERR 24
+ISR_NOERR 25
+ISR_NOERR 26
+ISR_NOERR 27
+ISR_NOERR 28
+ISR_NOERR 29
+ISR_NOERR 30
+ISR_NOERR 31
+
+IRQ 32,0
+IRQ 33,1
+IRQ 34,2
+IRQ 35,3
+IRQ 36,4
+IRQ 37,5
+IRQ 38,6
+IRQ 39,7
+IRQ 40,8
+IRQ 41,9
+IRQ 42,10
+IRQ 43,11
+IRQ 44,12
+IRQ 45,13
+IRQ 46,14
+IRQ 47,15
+
+isr_common_stub:
+    push rax
+    push rbx
+    push rcx
+    push rdx
+    push rbp
+    push rdi
+    push rsi
+    push r8
+    push r9
+    push r10
+    push r11
+    push r12
+    push r13
+    push r14
+    push r15
+    mov rdi, rsp
+    call isr_common_handler
+    pop r15
+    pop r14
+    pop r13
+    pop r12
+    pop r11
+    pop r10
+    pop r9
+    pop r8
+    pop rsi
+    pop rdi
+    pop rbp
+    pop rdx
+    pop rcx
+    pop rbx
+    pop rax
+    add rsp, 16
+    iretq
+
+section .note.GNU-stack noalloc noexec nowrite

--- a/src/kernel/include/arch/interrupts.h
+++ b/src/kernel/include/arch/interrupts.h
@@ -1,0 +1,14 @@
+#pragma once
+#include <lib/types.h>
+
+typedef struct __attribute__((packed)) {
+    u64 r15, r14, r13, r12, r11, r10, r9, r8;
+    u64 rsi, rdi, rbp, rdx, rcx, rbx, rax;
+    u64 int_no, err_code;
+    u64 rip, cs, rflags, rsp, ss;
+} isr_frame_t;
+
+void idt_init(void);
+void pic_remap(u8 offset1, u8 offset2);
+void pic_send_eoi(u8 irq);
+void isr_common_handler(isr_frame_t *frame);

--- a/src/kernel/include/arch/interrupts.h
+++ b/src/kernel/include/arch/interrupts.h
@@ -1,14 +1,53 @@
 #pragma once
 #include <lib/types.h>
 
+/**
+ * @brief Struttura che rappresenta lo stato del processore al momento dell'interrupt
+ *
+ * Questa struttura viene popolata automaticamente dagli stub ISR quando
+ * un'interruzione (hardware o software) viene gestita. Serve per accedere
+ * ai registri salvati all'interno dell'handler in C.
+ */
 typedef struct __attribute__((packed)) {
-    u64 r15, r14, r13, r12, r11, r10, r9, r8;
-    u64 rsi, rdi, rbp, rdx, rcx, rbx, rax;
-    u64 int_no, err_code;
-    u64 rip, cs, rflags, rsp, ss;
+  // Registri generali salvati manualmente nello stub
+  u64 r15, r14, r13, r12, r11, r10, r9, r8;
+  u64 rsi, rdi, rbp, rdx, rcx, rbx, rax;
+
+  // Informazioni sull'interrupt (pushed dallo stub)
+  u64 int_no;   ///< Numero del vettore interrupt
+  u64 err_code; ///< Codice errore (solo per ISR con errore)
+
+  // Stato del processore salvato automaticamente dalla CPU
+  u64 rip;    ///< Instruction Pointer al momento dell'interrupt
+  u64 cs;     ///< Code Segment
+  u64 rflags; ///< Flags della CPU
+  u64 rsp;    ///< Stack Pointer
+  u64 ss;     ///< Stack Segment
 } isr_frame_t;
 
+/**
+ * @brief Inizializza la IDT (Interrupt Descriptor Table)
+ */
 void idt_init(void);
+
+/**
+ * @brief Rimappa il PIC per evitare conflitti con gli interrupt della CPU
+ *
+ * @param offset1 Offset base per IRQ del PIC master (di solito 0x20)
+ * @param offset2 Offset base per IRQ del PIC slave (di solito 0x28)
+ */
 void pic_remap(u8 offset1, u8 offset2);
+
+/**
+ * @brief Invia End Of Interrupt al PIC
+ *
+ * @param irq Numero IRQ gestito (necessario per riabilitare il prossimo IRQ)
+ */
 void pic_send_eoi(u8 irq);
+
+/**
+ * @brief Handler comune in C per tutti gli interrupt
+ *
+ * Questo viene invocato da `isr_common_stub` e riceve lo snapshot del contesto
+ */
 void isr_common_handler(isr_frame_t *frame);

--- a/src/kernel/include/arch/io.h
+++ b/src/kernel/include/arch/io.h
@@ -1,0 +1,12 @@
+#pragma once
+#include <lib/types.h>
+
+static inline void outb(u16 port, u8 value) {
+    __asm__ volatile("outb %0, %1" : : "a"(value), "Nd"(port));
+}
+
+static inline u8 inb(u16 port) {
+    u8 ret;
+    __asm__ volatile("inb %1, %0" : "=a"(ret) : "Nd"(port));
+    return ret;
+}

--- a/src/kernel/include/arch/io.h
+++ b/src/kernel/include/arch/io.h
@@ -1,12 +1,31 @@
 #pragma once
 #include <lib/types.h>
 
+/**
+ * @brief Scrive un byte (8 bit) su una porta I/O specifica (I/O Port Output)
+ *
+ * Utilizzato per inviare comandi o dati a dispositivi hardware mappati su porte I/O.
+ *
+ * @param port Porta I/O su cui scrivere
+ * @param value Valore da scrivere (8 bit)
+ */
 static inline void outb(u16 port, u8 value) {
-    __asm__ volatile("outb %0, %1" : : "a"(value), "Nd"(port));
+  __asm__ volatile("outb %0, %1" : : "a"(value), "Nd"(port));
+  // %0 = valore da scrivere (in registro AL)
+  // %1 = numero di porta (in DX)
 }
 
+/**
+ * @brief Legge un byte (8 bit) da una porta I/O specifica (I/O Port Input)
+ *
+ * Utilizzato per leggere dati da periferiche come tastiera, controller PIC, ecc.
+ *
+ * @param port Porta I/O da cui leggere
+ * @return Byte letto dalla porta
+ */
 static inline u8 inb(u16 port) {
-    u8 ret;
-    __asm__ volatile("inb %1, %0" : "=a"(ret) : "Nd"(port));
-    return ret;
+  u8 ret;
+  __asm__ volatile("inb %1, %0" : "=a"(ret) : "Nd"(port));
+  // %1 = numero di porta (in DX), %0 = valore restituito (in AL)
+  return ret;
 }

--- a/src/kernel/main.c
+++ b/src/kernel/main.c
@@ -1,10 +1,10 @@
+#include <arch/cpu.h>
+#include <arch/interrupts.h>
 #include <arch/memory.h>
 #include <bootloader/limine.h>
 #include <drivers/video/console.h>
 #include <drivers/video/framebuffer.h>
 #include <klib/klog.h>
-#include <arch/interrupts.h>
-#include <arch/cpu.h>
 #include <lib/stdio.h>
 #include <lib/string.h>
 #include <mm/heap/heap.h>
@@ -19,34 +19,6 @@
  */
 
 volatile struct limine_framebuffer_request framebuffer_request = {.id = LIMINE_FRAMEBUFFER_REQUEST, .revision = 0};
-
-void heap_self_test(void) {
-  klog_info("heap_self_test: inizio test allocatore heap...");
-  void *ptrs[64];
-
-  for (int i = 0; i < 64; ++i)
-    ptrs[i] = kmalloc(32 + (i % 5) * 16);
-
-  for (int i = 0; i < 64; ++i)
-    kfree(ptrs[i]);
-
-  if (!heap_check_integrity())
-    klog_error("heap_self_test: ERRORE di integrità heap!");
-  else
-    klog_info("heap_self_test: OK - allocazione e liberazione funzionano.");
-
-  klog_info("heap_self_test: test su allocazioni grandi (buddy)...");
-
-  void *big1 = kmalloc(64 * 1024);       // 64 KB
-  void *big2 = kmalloc(512 * 1024);      // 512 KB
-  void *big3 = kmalloc(2 * 1024 * 1024); // 2 MB
-
-  kfree(big1);
-  kfree(big2);
-  kfree(big3);
-
-  klog_info("heap_self_test: allocazioni grandi liberate correttamente");
-}
 
 /*
  * ============================================================================
@@ -119,8 +91,6 @@ void kmain(void) {
   klog_info("=== MICROKERNEL INITIALIZATION COMPLETE ===");
   klog_info("All tests completed - ZONE-OS microkernel ready");
 
-  klog_info("Running comprehensive heap tests...");
-  heap_self_test(); // ✅ CHIAMATA AGGIUNTA QUI
   while (1) {
     __asm__ volatile("hlt");
   }

--- a/src/kernel/main.c
+++ b/src/kernel/main.c
@@ -3,6 +3,8 @@
 #include <drivers/video/console.h>
 #include <drivers/video/framebuffer.h>
 #include <klib/klog.h>
+#include <arch/interrupts.h>
+#include <arch/cpu.h>
 #include <lib/stdio.h>
 #include <lib/string.h>
 #include <mm/heap/heap.h>
@@ -87,6 +89,15 @@ void kmain(void) {
   klog_info("Initializing Virtual Memory Manager...");
   vmm_init();
   klog_info("VMM initialized successfully");
+
+  /*
+   * FASE 4: INIZIALIZZAZIONE GESTIONE INTERRUPT
+   */
+  klog_info("Initializing IDT and PIC...");
+  idt_init();
+  pic_remap(0x20, 0x28);
+  cpu_enable_interrupts();
+  klog_info("Interrupts enabled");
 
   /*
    * FASE 5: TEST HEAP COMPLETI


### PR DESCRIPTION
## Summary
- add generic interrupt interfaces and port IO helpers
- implement IDT and PIC setup for x86_64
- provide assembly ISR/IRQ stubs and default handler
- hook interrupt initialization in `kmain`