### PR TITLE
Implement full x86_64 interrupt stubs

### DIFF
--- a/src/kernel/include/arch/x86_64/interrupt_context.h
+++ b/src/kernel/include/arch/x86_64/interrupt_context.h
@@ -16,23 +16,23 @@
  * - contesto automatico salvato dalla CPU (RIP, CS, RFLAGS, RSP, SS)
  */
 
-typedef struct arch_interrupt_context {
+typedef struct __attribute__((packed)) arch_interrupt_context {
   // --- Registri pushati manualmente dallo stub ---
-  u64 r15;
-  u64 r14;
-  u64 r13;
-  u64 r12;
-  u64 r11;
-  u64 r10;
-  u64 r9;
-  u64 r8;
-  u64 rbp;
-  u64 rdi;
-  u64 rsi;
-  u64 rdx;
-  u64 rcx;
-  u64 rbx;
   u64 rax;
+  u64 rbx;
+  u64 rcx;
+  u64 rdx;
+  u64 rbp;
+  u64 rsi;
+  u64 rdi;
+  u64 r8;
+  u64 r9;
+  u64 r10;
+  u64 r11;
+  u64 r12;
+  u64 r13;
+  u64 r14;
+  u64 r15;
 
   // --- Informazioni specifiche dell'interrupt ---
   u64 interrupt_vector; // pushato a mano o via macro


### PR DESCRIPTION
## Summary
- Reorder and pack CPU interrupt context to mirror stack layout
- Generate 256 x86_64 ISR stubs with unified save/restore macros

## Testing
- `apt-get install -y clang nasm lld`
- `make -C src/kernel`

------
https://chatgpt.com/codex/tasks/task_e_68924f71b8cc8328bb961f99bf537798