### PR TITLE
docs: define the new educational OS project

### DIFF
--- a/docs/new-project/API_ROADMAP.md
+++ b/docs/new-project/API_ROADMAP.md
@@ -1,0 +1,1299 @@
+# Roadmap delle API per milestone
+
+## Scopo
+
+Questo documento raccoglie le API previste per ogni milestone. Le firme sono contratti di progetto iniziali: guidano lo studio, la progettazione e i test, ma possono evolvere tramite ADR quando l'implementazione dimostra requisiti diversi.
+
+Ogni milestone deve produrre:
+
+- header pubblici minimi;
+- implementazioni private;
+- documentazione di ownership e lifetime;
+- codici di errore stabili;
+- test delle API;
+- almeno un caso di fallimento deliberato;
+- separazione tra contratto generico e backend x86_64;
+- nessuna esposizione accidentale di strutture private.
+
+## Convenzioni comuni
+
+### Tipi opachi
+
+```c
+struct address_space;
+struct thread;
+struct process;
+struct ipc_endpoint;
+struct file;
+struct vnode;
+```
+
+La definizione completa resta nel modulo proprietario.
+
+### Handle
+
+```c
+typedef struct {
+    uint64_t value;
+} object_handle_t;
+```
+
+Gli handle sono preferiti nelle API destinate a poter attraversare un futuro confine IPC.
+
+### Indirizzi tipizzati
+
+```c
+typedef struct {
+    uintptr_t value;
+} paddr_t;
+
+typedef struct {
+    uintptr_t value;
+} vaddr_t;
+```
+
+Le conversioni tra indirizzi fisici, virtuali e puntatori devono essere esplicite.
+
+### Risultati
+
+Le operazioni recuperabili restituiscono enum tipizzati. Gli output vengono restituiti tramite parametri `out` validati.
+
+```c
+enum kernel_status {
+    KERNEL_OK,
+    KERNEL_INVALID_ARGUMENT,
+    KERNEL_OUT_OF_MEMORY,
+    KERNEL_NOT_FOUND,
+    KERNEL_PERMISSION_DENIED,
+    KERNEL_BUSY,
+    KERNEL_UNSUPPORTED,
+    KERNEL_IO_ERROR,
+};
+```
+
+Non tutte le API devono usare un unico enum globale. I sottosistemi possono definire errori più precisi, purché siano convertibili in uno stato comune ai confini pubblici.
+
+---
+
+# M0 — Workspace e build
+
+Questa milestone non introduce ancora API runtime del kernel. Introduce però l'interfaccia degli strumenti di sviluppo.
+
+## Comandi pubblici
+
+```text
+./tools/dev setup
+./tools/dev configure [debug|release|test]
+./tools/dev build [target]
+./tools/dev run [--no-build]
+./tools/dev debug
+./tools/dev test [suite]
+./tools/dev inspect
+./tools/dev clean
+```
+
+## Contratto dello strumento
+
+```text
+setup      -> valida le dipendenze senza installarle silenziosamente
+configure  -> crea una directory Meson riproducibile
+build      -> esegue una build incrementale
+run        -> avvia QEMU con configurazione deterministica
+debug      -> avvia QEMU e collega GDB
+test       -> esegue test host o kernel selezionati
+inspect    -> mostra proprietà ELF e dipendenze
+clean      -> rimuove solo artefatti generati
+```
+
+## API di configurazione build
+
+Opzioni Meson candidate:
+
+```text
+-Darchitecture=x86_64
+-Dfirmware=uefi
+-Dboot_protocol=limine
+-Dkernel_tests=true|false
+-Ddiagnostics=basic|full
+-Dtoolchain=clang|zig
+```
+
+---
+
+# M1 — Boot controllato
+
+## Header pubblici candidati
+
+```text
+kernel/include/boot/info.h
+kernel/include/core/halt.h
+kernel/include/drivers/byte_sink.h
+```
+
+## Informazioni di boot normalizzate
+
+```c
+enum boot_memory_type {
+    BOOT_MEMORY_USABLE,
+    BOOT_MEMORY_RESERVED,
+    BOOT_MEMORY_RECLAIMABLE,
+    BOOT_MEMORY_KERNEL,
+    BOOT_MEMORY_MODULE,
+    BOOT_MEMORY_FRAMEBUFFER,
+    BOOT_MEMORY_MMIO,
+};
+
+struct boot_memory_region {
+    paddr_t base;
+    uint64_t length;
+    enum boot_memory_type type;
+};
+
+struct boot_module {
+    paddr_t physical_base;
+    uint64_t size;
+    const char *name;
+};
+
+struct boot_info;
+```
+
+## API generiche
+
+```c
+[[nodiscard]]
+bool boot_info_capture(struct boot_info *out_info);
+
+[[nodiscard]]
+size_t boot_info_memory_region_count(const struct boot_info *info);
+
+[[nodiscard]]
+bool boot_info_memory_region_at(
+    const struct boot_info *info,
+    size_t index,
+    struct boot_memory_region *out_region
+);
+
+[[nodiscard]]
+size_t boot_info_module_count(const struct boot_info *info);
+
+[[nodiscard]]
+bool boot_info_module_at(
+    const struct boot_info *info,
+    size_t index,
+    struct boot_module *out_module
+);
+
+[[noreturn]]
+void platform_halt(void);
+```
+
+## Output diagnostico iniziale
+
+```c
+struct byte_sink;
+
+enum byte_sink_status {
+    BYTE_SINK_OK,
+    BYTE_SINK_UNAVAILABLE,
+    BYTE_SINK_IO_ERROR,
+};
+
+[[nodiscard]]
+enum byte_sink_status byte_sink_write(
+    struct byte_sink *sink,
+    const void *data,
+    size_t size
+);
+```
+
+## Backend x86_64
+
+```c
+[[nodiscard]] bool x86_64_limine_capture(struct boot_info *out_info);
+[[nodiscard]] bool x86_64_serial_init(struct byte_sink **out_sink);
+[[noreturn]] void x86_64_halt(void);
+```
+
+Il codice generico non include `limine.h`.
+
+---
+
+# M2 — Logging, panic ed eccezioni
+
+## Logging
+
+```c
+enum log_level {
+    LOG_TRACE,
+    LOG_DEBUG,
+    LOG_INFO,
+    LOG_WARNING,
+    LOG_ERROR,
+    LOG_FATAL,
+};
+
+struct log_record {
+    enum log_level level;
+    const char *component;
+    const char *message;
+};
+
+void log_set_sink(struct byte_sink *sink);
+
+void log_write(
+    enum log_level level,
+    const char *component,
+    const char *format,
+    ...
+);
+```
+
+## Panic
+
+```c
+struct source_location {
+    const char *file;
+    const char *function;
+    uint32_t line;
+};
+
+[[noreturn]]
+void panic_at(
+    struct source_location location,
+    const char *format,
+    ...
+);
+
+#define PANIC(...) \
+    panic_at(       \
+        (struct source_location){__FILE__, __func__, __LINE__}, \
+        __VA_ARGS__ \
+    )
+```
+
+## Eccezioni
+
+```c
+enum exception_class {
+    EXCEPTION_ARITHMETIC,
+    EXCEPTION_INVALID_INSTRUCTION,
+    EXCEPTION_MEMORY_ACCESS,
+    EXCEPTION_BREAKPOINT,
+    EXCEPTION_PROTECTION,
+    EXCEPTION_HARDWARE_FAILURE,
+    EXCEPTION_UNKNOWN,
+};
+
+struct execution_view {
+    vaddr_t instruction_pointer;
+    vaddr_t stack_pointer;
+    uintptr_t flags;
+    bool from_user;
+};
+
+struct exception_info {
+    enum exception_class class;
+    uint32_t architecture_code;
+    uint64_t architecture_error;
+    vaddr_t fault_address;
+};
+
+void exception_dispatch(
+    const struct exception_info *info,
+    const struct execution_view *view,
+    const void *architecture_context
+);
+```
+
+## Backend x86_64
+
+```c
+void x86_64_gdt_init(void);
+void x86_64_tss_init(void);
+void x86_64_idt_init(void);
+void x86_64_exceptions_enable(void);
+
+[[nodiscard]]
+bool x86_64_context_make_view(
+    const struct x86_64_interrupt_context *context,
+    struct execution_view *out_view
+);
+```
+
+---
+
+# M3 — Gestione della memoria fisica
+
+## Tipi
+
+```c
+typedef struct {
+    uint64_t value;
+} page_frame_t;
+
+enum pmm_status {
+    PMM_OK,
+    PMM_INVALID_ARGUMENT,
+    PMM_OUT_OF_MEMORY,
+    PMM_NOT_OWNED,
+    PMM_ALREADY_RESERVED,
+    PMM_DOUBLE_FREE,
+};
+
+struct pmm_statistics {
+    uint64_t total_pages;
+    uint64_t usable_pages;
+    uint64_t free_pages;
+    uint64_t reserved_pages;
+};
+```
+
+## API
+
+```c
+[[nodiscard]]
+enum pmm_status pmm_init(const struct boot_info *boot_info);
+
+[[nodiscard]]
+enum pmm_status pmm_reserve_range(
+    paddr_t base,
+    uint64_t length
+);
+
+[[nodiscard]]
+enum pmm_status pmm_release_range(
+    paddr_t base,
+    uint64_t length
+);
+
+[[nodiscard]]
+enum pmm_status pmm_alloc_page(paddr_t *out_page);
+
+[[nodiscard]]
+enum pmm_status pmm_alloc_pages(
+    size_t count,
+    size_t alignment_pages,
+    paddr_t *out_base
+);
+
+[[nodiscard]]
+enum pmm_status pmm_free_page(paddr_t page);
+
+[[nodiscard]]
+enum pmm_status pmm_free_pages(
+    paddr_t base,
+    size_t count
+);
+
+void pmm_get_statistics(struct pmm_statistics *out_stats);
+
+[[nodiscard]]
+bool pmm_validate_integrity(void);
+```
+
+---
+
+# M4 — Gestione della memoria virtuale
+
+## Tipi
+
+```c
+struct address_space;
+
+enum vm_permission {
+    VM_READ    = 1u << 0,
+    VM_WRITE   = 1u << 1,
+    VM_EXECUTE = 1u << 2,
+    VM_USER    = 1u << 3,
+    VM_GLOBAL  = 1u << 4,
+};
+
+enum vm_status {
+    VM_OK,
+    VM_INVALID_ARGUMENT,
+    VM_INVALID_ADDRESS,
+    VM_ALREADY_MAPPED,
+    VM_NOT_MAPPED,
+    VM_OUT_OF_MEMORY,
+    VM_PERMISSION_ERROR,
+};
+
+struct vm_mapping {
+    vaddr_t virtual_address;
+    paddr_t physical_address;
+    size_t page_count;
+    uint32_t permissions;
+};
+```
+
+## API generiche
+
+```c
+[[nodiscard]]
+enum vm_status address_space_create(
+    struct address_space **out_space
+);
+
+void address_space_retain(struct address_space *space);
+void address_space_release(struct address_space *space);
+
+[[nodiscard]]
+enum vm_status address_space_activate(
+    struct address_space *space
+);
+
+[[nodiscard]]
+enum vm_status vm_map(
+    struct address_space *space,
+    const struct vm_mapping *mapping
+);
+
+[[nodiscard]]
+enum vm_status vm_unmap(
+    struct address_space *space,
+    vaddr_t virtual_address,
+    size_t page_count
+);
+
+[[nodiscard]]
+enum vm_status vm_query(
+    const struct address_space *space,
+    vaddr_t virtual_address,
+    struct vm_mapping *out_mapping
+);
+
+[[nodiscard]]
+enum vm_status vm_protect(
+    struct address_space *space,
+    vaddr_t virtual_address,
+    size_t page_count,
+    uint32_t permissions
+);
+```
+
+## Backend architetturale
+
+```c
+struct arch_address_space;
+
+[[nodiscard]]
+enum vm_status arch_vm_space_create(
+    struct arch_address_space **out_space
+);
+
+void arch_vm_space_destroy(struct arch_address_space *space);
+
+[[nodiscard]]
+enum vm_status arch_vm_activate(
+    struct arch_address_space *space
+);
+
+void arch_vm_invalidate_page(vaddr_t address);
+void arch_vm_invalidate_space(struct arch_address_space *space);
+```
+
+Il backend x86_64 traduce `vm_permission` nei bit delle page table.
+
+---
+
+# M5 — Heap del kernel
+
+## Tipi
+
+```c
+enum heap_status {
+    HEAP_OK,
+    HEAP_INVALID_ARGUMENT,
+    HEAP_OUT_OF_MEMORY,
+    HEAP_CORRUPTED,
+    HEAP_INVALID_POINTER,
+    HEAP_DOUBLE_FREE,
+};
+
+struct heap_statistics {
+    size_t committed_bytes;
+    size_t allocated_bytes;
+    size_t free_bytes;
+    size_t allocation_count;
+};
+```
+
+## API
+
+```c
+[[nodiscard]]
+enum heap_status heap_init(void);
+
+[[nodiscard]]
+void *kmalloc(size_t size);
+
+[[nodiscard]]
+void *kcalloc(size_t count, size_t size);
+
+[[nodiscard]]
+void *krealloc(void *pointer, size_t new_size);
+
+[[nodiscard]]
+void *kmalloc_aligned(size_t size, size_t alignment);
+
+void kfree(void *pointer);
+
+void heap_get_statistics(struct heap_statistics *out_stats);
+
+[[nodiscard]]
+bool heap_validate_integrity(void);
+```
+
+Per le API interne critiche può essere preferibile una variante esplicita:
+
+```c
+[[nodiscard]]
+enum heap_status heap_allocate(
+    size_t size,
+    size_t alignment,
+    void **out_pointer
+);
+```
+
+---
+
+# M6 — Interrupt e tempo
+
+## Interrupt
+
+```c
+typedef struct {
+    uintptr_t value;
+} interrupt_source_t;
+
+typedef void (*interrupt_handler_fn)(
+    interrupt_source_t source,
+    void *context
+);
+
+enum interrupt_status {
+    INTERRUPT_OK,
+    INTERRUPT_INVALID_SOURCE,
+    INTERRUPT_ALREADY_REGISTERED,
+    INTERRUPT_NOT_REGISTERED,
+    INTERRUPT_UNSUPPORTED,
+};
+
+[[nodiscard]]
+enum interrupt_status interrupt_register(
+    interrupt_source_t source,
+    interrupt_handler_fn handler,
+    void *context
+);
+
+[[nodiscard]]
+enum interrupt_status interrupt_unregister(
+    interrupt_source_t source
+);
+
+[[nodiscard]]
+enum interrupt_status interrupt_mask(interrupt_source_t source);
+[[nodiscard]]
+enum interrupt_status interrupt_unmask(interrupt_source_t source);
+void interrupt_acknowledge(interrupt_source_t source);
+```
+
+## Tempo
+
+```c
+typedef struct {
+    uint64_t nanoseconds;
+} duration_t;
+
+typedef struct {
+    uint64_t nanoseconds;
+} monotonic_time_t;
+
+[[nodiscard]]
+monotonic_time_t clock_monotonic_now(void);
+
+[[nodiscard]]
+bool timer_set_deadline(monotonic_time_t deadline);
+
+void timer_cancel_deadline(void);
+```
+
+## Backend
+
+```c
+struct interrupt_controller_ops {
+    enum interrupt_status (*mask)(interrupt_source_t source);
+    enum interrupt_status (*unmask)(interrupt_source_t source);
+    void (*acknowledge)(interrupt_source_t source);
+};
+
+struct clock_source_ops {
+    uint64_t (*read_ticks)(void);
+    uint64_t frequency_hz;
+};
+```
+
+---
+
+# M7 — Thread e scheduler
+
+## Tipi
+
+```c
+struct thread;
+
+typedef uint64_t thread_id_t;
+
+typedef void (*thread_entry_fn)(void *argument);
+
+enum thread_state {
+    THREAD_NEW,
+    THREAD_READY,
+    THREAD_RUNNING,
+    THREAD_BLOCKED,
+    THREAD_TERMINATED,
+};
+
+enum scheduler_status {
+    SCHEDULER_OK,
+    SCHEDULER_INVALID_ARGUMENT,
+    SCHEDULER_OUT_OF_MEMORY,
+    SCHEDULER_INVALID_STATE,
+    SCHEDULER_NOT_FOUND,
+};
+```
+
+## API
+
+```c
+[[nodiscard]]
+enum scheduler_status scheduler_init(void);
+
+[[nodiscard]]
+enum scheduler_status thread_create_kernel(
+    thread_entry_fn entry,
+    void *argument,
+    struct thread **out_thread
+);
+
+thread_id_t thread_id(const struct thread *thread);
+enum thread_state thread_state_get(const struct thread *thread);
+
+void thread_retain(struct thread *thread);
+void thread_release(struct thread *thread);
+
+void scheduler_start(void);
+void scheduler_yield(void);
+
+[[nodiscard]]
+enum scheduler_status thread_block(void *wait_object);
+
+[[nodiscard]]
+enum scheduler_status thread_wake(struct thread *thread);
+
+[[noreturn]]
+void thread_exit(int exit_code);
+```
+
+## Backend del context switch
+
+```c
+struct arch_thread_context;
+
+[[nodiscard]]
+bool arch_thread_context_create(
+    struct arch_thread_context *out_context,
+    vaddr_t stack_top,
+    thread_entry_fn entry,
+    void *argument
+);
+
+void arch_context_switch(
+    struct arch_thread_context *from,
+    const struct arch_thread_context *to
+);
+```
+
+---
+
+# M8 — Processi e user mode
+
+## Tipi
+
+```c
+struct process;
+
+typedef uint64_t process_id_t;
+
+enum process_state {
+    PROCESS_NEW,
+    PROCESS_READY,
+    PROCESS_RUNNING,
+    PROCESS_BLOCKED,
+    PROCESS_TERMINATED,
+};
+
+enum process_status {
+    PROCESS_OK,
+    PROCESS_INVALID_ARGUMENT,
+    PROCESS_OUT_OF_MEMORY,
+    PROCESS_INVALID_ADDRESS,
+    PROCESS_PERMISSION_DENIED,
+    PROCESS_INVALID_STATE,
+};
+```
+
+## API
+
+```c
+[[nodiscard]]
+enum process_status process_create(
+    struct process **out_process
+);
+
+process_id_t process_id(const struct process *process);
+
+void process_retain(struct process *process);
+void process_release(struct process *process);
+
+[[nodiscard]]
+enum process_status process_set_image(
+    struct process *process,
+    struct address_space *address_space,
+    vaddr_t entry_point,
+    vaddr_t stack_pointer
+);
+
+[[nodiscard]]
+enum process_status process_start(struct process *process);
+
+[[nodiscard]]
+enum process_status process_terminate(
+    struct process *process,
+    int exit_code
+);
+
+[[nodiscard]]
+enum process_status copy_from_user(
+    void *kernel_destination,
+    vaddr_t user_source,
+    size_t size
+);
+
+[[nodiscard]]
+enum process_status copy_to_user(
+    vaddr_t user_destination,
+    const void *kernel_source,
+    size_t size
+);
+```
+
+## Backend x86_64
+
+```c
+[[nodiscard]]
+bool x86_64_user_context_create(
+    struct arch_thread_context *out_context,
+    vaddr_t entry_point,
+    vaddr_t user_stack,
+    vaddr_t kernel_stack
+);
+
+[[noreturn]]
+void x86_64_enter_user(
+    const struct arch_thread_context *context
+);
+```
+
+---
+
+# M9 — IPC, handle e syscall
+
+Questa milestone viene introdotta prima dei servizi filesystem persistenti per sostenere l'evoluzione ibrida.
+
+## Handle table
+
+```c
+enum handle_right {
+    HANDLE_RIGHT_READ     = 1u << 0,
+    HANDLE_RIGHT_WRITE    = 1u << 1,
+    HANDLE_RIGHT_TRANSFER = 1u << 2,
+    HANDLE_RIGHT_MAP      = 1u << 3,
+    HANDLE_RIGHT_SIGNAL   = 1u << 4,
+};
+
+[[nodiscard]]
+enum kernel_status handle_create(
+    struct process *owner,
+    void *object,
+    uint32_t rights,
+    object_handle_t *out_handle
+);
+
+[[nodiscard]]
+enum kernel_status handle_close(
+    struct process *owner,
+    object_handle_t handle
+);
+
+[[nodiscard]]
+enum kernel_status handle_duplicate(
+    struct process *owner,
+    object_handle_t source,
+    uint32_t reduced_rights,
+    object_handle_t *out_handle
+);
+```
+
+## Endpoint e messaggi
+
+```c
+#define IPC_INLINE_DATA_MAX 128u
+#define IPC_HANDLE_MAX 8u
+
+struct ipc_message {
+    uint32_t protocol;
+    uint32_t operation;
+    uint64_t request_id;
+    uint32_t flags;
+    uint32_t data_size;
+    uint8_t data[IPC_INLINE_DATA_MAX];
+    object_handle_t handles[IPC_HANDLE_MAX];
+    uint32_t handle_count;
+};
+
+enum ipc_status {
+    IPC_OK,
+    IPC_INVALID_ARGUMENT,
+    IPC_WOULD_BLOCK,
+    IPC_PEER_CLOSED,
+    IPC_MESSAGE_TOO_LARGE,
+    IPC_PERMISSION_DENIED,
+    IPC_INTERRUPTED,
+};
+
+[[nodiscard]]
+enum ipc_status ipc_endpoint_create(
+    object_handle_t *out_endpoint_a,
+    object_handle_t *out_endpoint_b
+);
+
+[[nodiscard]]
+enum ipc_status ipc_send(
+    object_handle_t endpoint,
+    const struct ipc_message *message
+);
+
+[[nodiscard]]
+enum ipc_status ipc_receive(
+    object_handle_t endpoint,
+    struct ipc_message *out_message
+);
+
+[[nodiscard]]
+enum ipc_status ipc_call(
+    object_handle_t endpoint,
+    const struct ipc_message *request,
+    struct ipc_message *out_reply
+);
+
+[[nodiscard]]
+enum ipc_status ipc_reply(
+    object_handle_t endpoint,
+    const struct ipc_message *reply
+);
+```
+
+## Memoria condivisa
+
+```c
+[[nodiscard]]
+enum kernel_status shared_memory_create(
+    size_t size,
+    object_handle_t *out_handle
+);
+
+[[nodiscard]]
+enum kernel_status shared_memory_map(
+    object_handle_t handle,
+    struct address_space *space,
+    vaddr_t preferred_address,
+    uint32_t permissions,
+    vaddr_t *out_address
+);
+```
+
+## Syscall ABI iniziale
+
+```c
+enum syscall_number : uint32_t {
+    SYS_WRITE,
+    SYS_EXIT,
+    SYS_YIELD,
+    SYS_HANDLE_CLOSE,
+    SYS_IPC_SEND,
+    SYS_IPC_RECEIVE,
+    SYS_IPC_CALL,
+};
+```
+
+L'entry assembly è specifica dell'architettura; la semantica del dispatcher è generica.
+
+```c
+struct syscall_request;
+struct syscall_result;
+
+void syscall_dispatch(
+    const struct syscall_request *request,
+    struct syscall_result *out_result
+);
+```
+
+---
+
+# M10 — Initramfs e caricatore ELF64
+
+## Sorgenti di byte
+
+```c
+struct byte_source {
+    const void *context;
+    enum kernel_status (*read)(
+        const void *context,
+        uint64_t offset,
+        void *destination,
+        size_t size
+    );
+    uint64_t size;
+};
+```
+
+## Initramfs
+
+```c
+struct archive;
+struct archive_entry;
+
+enum archive_status {
+    ARCHIVE_OK,
+    ARCHIVE_INVALID_FORMAT,
+    ARCHIVE_NOT_FOUND,
+    ARCHIVE_OUT_OF_BOUNDS,
+};
+
+[[nodiscard]]
+enum archive_status archive_open(
+    const struct byte_source *source,
+    struct archive **out_archive
+);
+
+void archive_close(struct archive *archive);
+
+[[nodiscard]]
+enum archive_status archive_lookup(
+    const struct archive *archive,
+    const char *path,
+    struct archive_entry *out_entry
+);
+```
+
+## ELF
+
+```c
+struct executable_image;
+
+struct executable_segment {
+    vaddr_t virtual_address;
+    uint64_t file_offset;
+    uint64_t file_size;
+    uint64_t memory_size;
+    uint32_t permissions;
+};
+
+enum elf_status {
+    ELF_OK,
+    ELF_INVALID_MAGIC,
+    ELF_UNSUPPORTED_CLASS,
+    ELF_UNSUPPORTED_MACHINE,
+    ELF_INVALID_HEADER,
+    ELF_INVALID_SEGMENT,
+    ELF_OUT_OF_BOUNDS,
+};
+
+[[nodiscard]]
+enum elf_status elf64_parse(
+    const struct byte_source *source,
+    struct executable_image **out_image
+);
+
+void executable_image_destroy(struct executable_image *image);
+
+[[nodiscard]]
+enum process_status process_load_executable(
+    struct process *process,
+    const struct executable_image *image
+);
+```
+
+---
+
+# M11 — VFS e filesystem locale
+
+Le API devono essere implementabili sia da un backend locale sia da un futuro proxy IPC.
+
+## Tipi
+
+```c
+struct vfs;
+struct file;
+
+typedef struct {
+    uint64_t value;
+} file_handle_t;
+
+enum file_type {
+    FILE_TYPE_REGULAR,
+    FILE_TYPE_DIRECTORY,
+    FILE_TYPE_CHARACTER_DEVICE,
+    FILE_TYPE_BLOCK_DEVICE,
+};
+
+enum fs_status {
+    FS_OK,
+    FS_INVALID_ARGUMENT,
+    FS_NOT_FOUND,
+    FS_ALREADY_EXISTS,
+    FS_NOT_DIRECTORY,
+    FS_IS_DIRECTORY,
+    FS_PERMISSION_DENIED,
+    FS_IO_ERROR,
+    FS_END_OF_FILE,
+};
+```
+
+## API pubbliche
+
+```c
+[[nodiscard]]
+enum fs_status vfs_init(struct vfs **out_vfs);
+
+[[nodiscard]]
+enum fs_status vfs_mount(
+    struct vfs *vfs,
+    const char *path,
+    object_handle_t filesystem
+);
+
+[[nodiscard]]
+enum fs_status file_open(
+    struct vfs *vfs,
+    const char *path,
+    uint32_t flags,
+    file_handle_t *out_file
+);
+
+[[nodiscard]]
+enum fs_status file_read(
+    file_handle_t file,
+    uint64_t offset,
+    void *buffer,
+    size_t size,
+    size_t *out_read
+);
+
+[[nodiscard]]
+enum fs_status file_write(
+    file_handle_t file,
+    uint64_t offset,
+    const void *buffer,
+    size_t size,
+    size_t *out_written
+);
+
+[[nodiscard]]
+enum fs_status file_close(file_handle_t file);
+```
+
+## Contratto del backend
+
+```c
+struct filesystem_ops {
+    enum fs_status (*open)(
+        void *context,
+        const char *path,
+        uint32_t flags,
+        object_handle_t *out_file
+    );
+
+    enum fs_status (*read)(
+        void *context,
+        object_handle_t file,
+        uint64_t offset,
+        void *buffer,
+        size_t size,
+        size_t *out_read
+    );
+
+    enum fs_status (*write)(
+        void *context,
+        object_handle_t file,
+        uint64_t offset,
+        const void *buffer,
+        size_t size,
+        size_t *out_written
+    );
+
+    enum fs_status (*close)(
+        void *context,
+        object_handle_t file
+    );
+};
+```
+
+Prima implementazione:
+
+```text
+client VFS -> backend initramfs locale
+```
+
+Evoluzione:
+
+```text
+client VFS -> proxy IPC -> filesystem server
+```
+
+---
+
+# M12 — Estrazione del primo servizio user space
+
+Questa milestone valida l'architettura ibrida evolutiva.
+
+## Service discovery
+
+```c
+typedef struct {
+    uint64_t value;
+} service_id_t;
+
+enum service_status {
+    SERVICE_OK,
+    SERVICE_NOT_FOUND,
+    SERVICE_ALREADY_REGISTERED,
+    SERVICE_UNAVAILABLE,
+    SERVICE_PERMISSION_DENIED,
+};
+
+[[nodiscard]]
+enum service_status service_register(
+    const char *name,
+    object_handle_t endpoint,
+    service_id_t *out_service
+);
+
+[[nodiscard]]
+enum service_status service_connect(
+    const char *name,
+    object_handle_t *out_endpoint
+);
+
+[[nodiscard]]
+enum service_status service_unregister(service_id_t service);
+```
+
+## Protocollo filesystem iniziale
+
+```c
+enum fs_protocol_operation : uint32_t {
+    FS_PROTOCOL_OPEN,
+    FS_PROTOCOL_READ,
+    FS_PROTOCOL_WRITE,
+    FS_PROTOCOL_CLOSE,
+};
+
+struct fs_open_request {
+    uint32_t flags;
+    uint32_t path_length;
+    char path[];
+};
+
+struct fs_open_reply {
+    enum fs_status status;
+    object_handle_t file;
+};
+```
+
+Le strutture a dimensione variabile dovranno essere validate con helper espliciti e non dereferenziate direttamente senza controllo dei limiti.
+
+## API del client
+
+Le API `file_open`, `file_read`, `file_write` e `file_close` non cambiano. Cambia soltanto il backend:
+
+```text
+filesystem_ops locale
+        ↓
+filesystem_ops proxy IPC
+```
+
+## Criterio di completamento
+
+La stessa suite contrattuale deve passare contro:
+
+```text
+backend_initramfs_local
+backend_filesystem_ipc
+```
+
+---
+
+# Modello di documentazione per ogni API
+
+Ogni API pubblica deve documentare:
+
+```text
+Nome
+Scopo
+Milestone di introduzione
+Header pubblico
+Contesto consentito
+Parametri
+Output
+Ownership
+Lifetime
+Thread safety
+Interrupt safety
+Possibili errori
+Effetti collaterali
+Backend iniziale
+Possibile backend remoto
+Test richiesti
+```
+
+Esempio:
+
+```c
+/**
+ * @brief Alloca una pagina fisica libera.
+ *
+ * Contesto: thread kernel; non consentita in NMI.
+ * Ownership: in caso di successo la pagina passa al chiamante.
+ * Errori: PMM_OUT_OF_MEMORY, PMM_INVALID_ARGUMENT.
+ * Thread safety: sì, dopo l'inizializzazione dello scheduler.
+ *
+ * @param out_page Riceve l'indirizzo fisico della pagina.
+ * @return Stato dell'operazione.
+ */
+[[nodiscard]]
+enum pmm_status pmm_alloc_page(paddr_t *out_page);
+```
+
+# Regole di evoluzione
+
+- Una firma pubblica non viene modificata senza aggiornare questa roadmap.
+- Una modifica incompatibile richiede ADR.
+- Le firme rappresentano intenzioni progettuali, non un vincolo immutabile.
+- Le API non ancora implementate devono essere marcate come pianificate, non aggiunte come stub fittizi.
+- Ogni milestone deve revisionare la propria sezione prima dell'implementazione.
+- Dopo la milestone, le firme effettive devono sostituire quelle proposte.
+- Le API condivise tra kernel e user space devono vivere in header di protocollo separati.
+- I dettagli x86_64 non devono apparire nei contratti generici salvo che siano parte esplicita di un backend architetturale.

--- a/docs/new-project/ARCHITECTURE.md
+++ b/docs/new-project/ARCHITECTURE.md
@@ -1,0 +1,134 @@
+# Architecture
+
+## Overview
+
+The first version is a modular monolithic kernel targeting x86_64. Architecture-specific code is isolated, but portability is not allowed to complicate the first implementation.
+
+```text
+Bootloader
+    |
+    v
+Architecture bootstrap
+    |
+    +--> Serial diagnostics
+    +--> CPU tables and exceptions
+    +--> Physical memory manager
+    +--> Virtual memory manager
+    +--> Kernel heap
+    +--> Interrupt controller and timer
+    +--> Scheduler
+    +--> User mode and system calls
+    +--> VFS, initramfs and ELF loader
+```
+
+## Proposed source tree
+
+```text
+kernel/
+├── arch/
+│   └── x86_64/
+│       ├── boot/
+│       ├── cpu/
+│       ├── interrupts/
+│       ├── memory/
+│       └── platform/
+├── core/
+│   ├── init/
+│   ├── panic/
+│   ├── log/
+│   └── scheduler/
+├── mm/
+│   ├── pmm/
+│   ├── vmm/
+│   └── heap/
+├── drivers/
+│   ├── serial/
+│   ├── timer/
+│   └── console/
+├── fs/
+│   ├── vfs/
+│   └── initramfs/
+├── process/
+├── syscall/
+└── lib/
+include/
+├── kernel/
+└── arch/x86_64/
+tests/
+├── host/
+└── kernel/
+tools/
+docs/
+```
+
+## Layering rules
+
+- Generic kernel code must not include private architecture headers.
+- Architecture code may depend on generic kernel interfaces where initialization order permits it.
+- Hardware drivers must expose small interfaces and avoid leaking register layouts into unrelated modules.
+- Memory managers must not print directly; they report errors through status values or the logging interface.
+- The panic path must avoid dynamic allocation.
+- Boot-time code must validate all bootloader responses before dereferencing them.
+
+## Boot sequence
+
+1. Limine loads the kernel ELF and transfers control.
+2. The entry code establishes the minimum required CPU state.
+3. The serial port is initialized.
+4. Bootloader responses and memory-map information are validated.
+5. GDT, TSS and IDT are installed.
+6. CPU exception handlers are enabled.
+7. The physical memory manager is initialized.
+8. Kernel-owned page tables are established.
+9. The kernel heap is initialized.
+10. Interrupt controller and timer are configured.
+11. The scheduler starts the idle thread and initial kernel tasks.
+12. The first user process is loaded when user mode becomes available.
+
+## Memory architecture
+
+The early design uses:
+
+- 4 KiB base pages;
+- a high-half kernel;
+- an explicit direct physical-memory map;
+- a bitmap physical page allocator;
+- separate address-space objects;
+- non-executable data, heap and stack pages where supported;
+- guard pages for important stacks;
+- explicit mapping, unmapping and address-resolution APIs.
+
+Physical and virtual addresses should use distinct project types such as `paddr_t` and `vaddr_t`. Conversions must be explicit.
+
+## Execution model
+
+The initial scheduler is single-core and preemptive. It first supports kernel threads, then processes with independent address spaces.
+
+Initial thread states:
+
+```text
+NEW -> READY -> RUNNING -> BLOCKED
+                 |           |
+                 +--> READY <-+
+                 |
+                 +--> DEAD
+```
+
+## System-call boundary
+
+The system-call ABI is introduced only after Ring 3 works reliably. All user pointers must be validated before use. The initial ABI should stay intentionally small and versioned.
+
+Candidate first calls:
+
+- `write`
+- `exit`
+- `yield`
+- `mmap`
+- `munmap`
+- `spawn`
+
+## Error-handling policy
+
+Recoverable operations return typed status values. Fatal invariants invoke `panic()` with source location and machine state when available.
+
+Assertions are enabled in debug builds. Release builds may remove expensive diagnostics but must not depend on assertions for correctness.

--- a/docs/new-project/ARCHITECTURE.md
+++ b/docs/new-project/ARCHITECTURE.md
@@ -1,27 +1,27 @@
-# Architecture
+# Architettura
 
-## Overview
+## Panoramica
 
-The first version is a modular monolithic kernel targeting x86_64. Architecture-specific code is isolated, but portability is not allowed to complicate the first implementation.
+La prima versione è un kernel monolitico modulare destinato a x86_64. Il codice specifico dell'architettura è isolato, ma la portabilità non deve complicare la prima implementazione.
 
 ```text
 Bootloader
     |
     v
-Architecture bootstrap
+Bootstrap dell'architettura
     |
-    +--> Serial diagnostics
-    +--> CPU tables and exceptions
-    +--> Physical memory manager
-    +--> Virtual memory manager
-    +--> Kernel heap
-    +--> Interrupt controller and timer
+    +--> Diagnostica seriale
+    +--> Tabelle CPU ed eccezioni
+    +--> Gestore della memoria fisica
+    +--> Gestore della memoria virtuale
+    +--> Heap del kernel
+    +--> Controller degli interrupt e timer
     +--> Scheduler
-    +--> User mode and system calls
-    +--> VFS, initramfs and ELF loader
+    +--> Modalità utente e chiamate di sistema
+    +--> VFS, initramfs e caricatore ELF
 ```
 
-## Proposed source tree
+## Struttura proposta dei sorgenti
 
 ```text
 kernel/
@@ -61,50 +61,50 @@ tools/
 docs/
 ```
 
-## Layering rules
+## Regole di stratificazione
 
-- Generic kernel code must not include private architecture headers.
-- Architecture code may depend on generic kernel interfaces where initialization order permits it.
-- Hardware drivers must expose small interfaces and avoid leaking register layouts into unrelated modules.
-- Memory managers must not print directly; they report errors through status values or the logging interface.
-- The panic path must avoid dynamic allocation.
-- Boot-time code must validate all bootloader responses before dereferencing them.
+- Il codice generico del kernel non deve includere header privati dell'architettura.
+- Il codice dell'architettura può dipendere dalle interfacce generiche del kernel quando l'ordine di inizializzazione lo consente.
+- I driver hardware devono esporre interfacce piccole ed evitare di propagare il layout dei registri in moduli non correlati.
+- I gestori della memoria non devono stampare direttamente; riportano gli errori tramite valori di stato o l'interfaccia di logging.
+- Il percorso di panic non deve usare allocazione dinamica.
+- Il codice di boot deve validare tutte le risposte del bootloader prima di dereferenziarle.
 
-## Boot sequence
+## Sequenza di boot
 
-1. Limine loads the kernel ELF and transfers control.
-2. The entry code establishes the minimum required CPU state.
-3. The serial port is initialized.
-4. Bootloader responses and memory-map information are validated.
-5. GDT, TSS and IDT are installed.
-6. CPU exception handlers are enabled.
-7. The physical memory manager is initialized.
-8. Kernel-owned page tables are established.
-9. The kernel heap is initialized.
-10. Interrupt controller and timer are configured.
-11. The scheduler starts the idle thread and initial kernel tasks.
-12. The first user process is loaded when user mode becomes available.
+1. Limine carica il kernel ELF e trasferisce il controllo.
+2. Il codice di ingresso stabilisce lo stato minimo richiesto della CPU.
+3. Viene inizializzata la porta seriale.
+4. Vengono validate le risposte del bootloader e le informazioni della mappa di memoria.
+5. Vengono installate GDT, TSS e IDT.
+6. Vengono abilitati gli handler delle eccezioni CPU.
+7. Viene inizializzato il gestore della memoria fisica.
+8. Vengono create le page table di proprietà del kernel.
+9. Viene inizializzato l'heap del kernel.
+10. Vengono configurati controller degli interrupt e timer.
+11. Lo scheduler avvia il thread idle e i task iniziali del kernel.
+12. Il primo processo utente viene caricato quando la modalità utente è disponibile.
 
-## Memory architecture
+## Architettura della memoria
 
-The early design uses:
+Il progetto iniziale usa:
 
-- 4 KiB base pages;
-- a high-half kernel;
-- an explicit direct physical-memory map;
-- a bitmap physical page allocator;
-- separate address-space objects;
-- non-executable data, heap and stack pages where supported;
-- guard pages for important stacks;
-- explicit mapping, unmapping and address-resolution APIs.
+- pagine base da 4 KiB;
+- kernel high-half;
+- direct map esplicita della memoria fisica;
+- allocatore di pagine fisiche basato su bitmap;
+- oggetti address space separati;
+- pagine dati, heap e stack non eseguibili quando supportato;
+- guard page per gli stack importanti;
+- API esplicite di mapping, unmapping e risoluzione degli indirizzi.
 
-Physical and virtual addresses should use distinct project types such as `paddr_t` and `vaddr_t`. Conversions must be explicit.
+Gli indirizzi fisici e virtuali devono usare tipi distinti del progetto, come `paddr_t` e `vaddr_t`. Le conversioni devono essere esplicite.
 
-## Execution model
+## Modello di esecuzione
 
-The initial scheduler is single-core and preemptive. It first supports kernel threads, then processes with independent address spaces.
+Lo scheduler iniziale è single-core e preemptive. Supporta prima i kernel thread, poi i processi con address space indipendenti.
 
-Initial thread states:
+Stati iniziali dei thread:
 
 ```text
 NEW -> READY -> RUNNING -> BLOCKED
@@ -114,11 +114,11 @@ NEW -> READY -> RUNNING -> BLOCKED
                  +--> DEAD
 ```
 
-## System-call boundary
+## Confine delle chiamate di sistema
 
-The system-call ABI is introduced only after Ring 3 works reliably. All user pointers must be validated before use. The initial ABI should stay intentionally small and versioned.
+L'ABI delle chiamate di sistema viene introdotta solo dopo che Ring 3 funziona in modo affidabile. Tutti i puntatori provenienti dallo user space devono essere validati prima dell'uso. L'ABI iniziale deve restare volutamente piccola e versionata.
 
-Candidate first calls:
+Prime chiamate candidate:
 
 - `write`
 - `exit`
@@ -127,8 +127,8 @@ Candidate first calls:
 - `munmap`
 - `spawn`
 
-## Error-handling policy
+## Politica di gestione degli errori
 
-Recoverable operations return typed status values. Fatal invariants invoke `panic()` with source location and machine state when available.
+Le operazioni recuperabili restituiscono valori di stato tipizzati. Le violazioni fatali delle invarianti invocano `panic()` con posizione nel sorgente e stato della macchina, quando disponibili.
 
-Assertions are enabled in debug builds. Release builds may remove expensive diagnostics but must not depend on assertions for correctness.
+Le assertion sono abilitate nelle build debug. Le build release possono rimuovere diagnostica costosa, ma non devono dipendere dalle assertion per la correttezza.

--- a/docs/new-project/BUILD_SYSTEM.md
+++ b/docs/new-project/BUILD_SYSTEM.md
@@ -1,0 +1,143 @@
+# Build System
+
+## Objectives
+
+The build must be fast enough for daily development, simple enough to explain in a video and reproducible enough for CI.
+
+The build system must:
+
+- compile incrementally;
+- track header dependencies correctly;
+- support parallel compilation;
+- separate source and generated files;
+- provide debug, release and test configurations;
+- keep image generation separate from kernel compilation;
+- avoid requiring Docker for every edit;
+- pin external tool versions where practical.
+
+## Selected tools
+
+- Meson: project configuration and dependency graph.
+- Ninja: incremental build execution.
+- Clang: primary C23 compiler.
+- LLD: primary linker.
+- Python: small portable orchestration tools.
+- QEMU: emulation and integration testing.
+- GDB: source-level debugging.
+- Limine: boot protocol and bootloader.
+
+## Build stages
+
+```text
+C and assembly sources
+        |
+        v
+Object files
+        |
+        v
+kernel.elf
+        |
+        +----> debug symbols and map file
+        |
+        v
+staged boot tree
+        |
+        v
+UEFI image
+        |
+        v
+QEMU
+```
+
+Each stage must be represented by explicit inputs and outputs. A stage runs only when its inputs change.
+
+## Expected commands
+
+The public interface should remain small:
+
+```bash
+./tools/dev setup
+./tools/dev build
+./tools/dev run
+./tools/dev debug
+./tools/dev test
+./tools/dev clean
+```
+
+`tools/dev` is only a thin command dispatcher. It must not reimplement compiler dependency logic.
+
+Equivalent lower-level commands remain documented:
+
+```bash
+meson setup build/debug --cross-file config/x86_64.ini --buildtype=debug
+meson compile -C build/debug
+```
+
+## Build profiles
+
+### Debug
+
+- debug information;
+- frame pointers;
+- assertions;
+- detailed logging;
+- allocator integrity checks;
+- minimal optimization.
+
+### Release
+
+- optimized kernel;
+- reduced logging;
+- separate or preserved symbols for postmortem debugging;
+- no correctness dependency on disabled assertions.
+
+### Test
+
+- test registry enabled;
+- deterministic QEMU configuration;
+- machine-readable exit code;
+- optional fault-injection targets.
+
+## Image-generation policy
+
+Kernel compilation and boot-image construction are separate targets. Recompiling a source file must not repartition or reformat an image unless the kernel ELF actually changed.
+
+The first release targets UEFI only. Legacy BIOS support is a later, isolated feature.
+
+The staged boot tree should look like:
+
+```text
+build/debug/sysroot/
+├── boot/
+│   ├── kernel.elf
+│   └── limine.conf
+└── EFI/
+    └── BOOT/
+        └── BOOTX64.EFI
+```
+
+## Dependency management
+
+External bootloader artifacts must be pinned to a known version. Downloads should be verified with a checksum. The repository should not depend on mutable files installed at paths such as `/opt/limine`.
+
+Host dependencies are checked by `tools/dev setup`. That command reports missing tools and does not silently install system packages.
+
+## Container policy
+
+Local development uses the native toolchain for speed. A container image provides a reproducible reference environment for CI and users who prefer isolation.
+
+The container must not be rebuilt for each source change. Source directories may be mounted into a previously built development image.
+
+## Performance expectations
+
+After the initial configuration:
+
+- no-op build should complete almost immediately;
+- editing one C file should compile one object and relink;
+- documentation changes should not rebuild the kernel;
+- QEMU launch should not trigger a clean build;
+- test selection should avoid running unrelated suites.
+
+## Build observability
+
+The build should be inspectable with standard Meson and Ninja tooling. Custom scripts must print the exact failed command and return its exit status unchanged.

--- a/docs/new-project/BUILD_SYSTEM.md
+++ b/docs/new-project/BUILD_SYSTEM.md
@@ -1,59 +1,59 @@
-# Build System
+# Sistema di build
 
-## Objectives
+## Obiettivi
 
-The build must be fast enough for daily development, simple enough to explain in a video and reproducible enough for CI.
+La build deve essere abbastanza veloce per lo sviluppo quotidiano, abbastanza semplice da spiegare in un video e abbastanza riproducibile per la CI.
 
-The build system must:
+Il sistema di build deve:
 
-- compile incrementally;
-- track header dependencies correctly;
-- support parallel compilation;
-- separate source and generated files;
-- provide debug, release and test configurations;
-- keep image generation separate from kernel compilation;
-- avoid requiring Docker for every edit;
-- pin external tool versions where practical.
+- compilare in modo incrementale;
+- tracciare correttamente le dipendenze dagli header;
+- supportare la compilazione parallela;
+- separare sorgenti e file generati;
+- offrire configurazioni debug, release e test;
+- mantenere separata la generazione dell'immagine dalla compilazione del kernel;
+- evitare di richiedere Docker a ogni modifica;
+- fissare le versioni degli strumenti esterni quando pratico.
 
-## Selected tools
+## Strumenti scelti
 
-- Meson: project configuration and dependency graph.
-- Ninja: incremental build execution.
-- Clang: primary C23 compiler.
-- LLD: primary linker.
-- Python: small portable orchestration tools.
-- QEMU: emulation and integration testing.
-- GDB: source-level debugging.
-- Limine: boot protocol and bootloader.
+- Meson: configurazione del progetto e grafo delle dipendenze.
+- Ninja: esecuzione incrementale della build.
+- Clang: compilatore C23 principale.
+- LLD: linker principale.
+- Python: piccoli strumenti portabili di orchestrazione.
+- QEMU: emulazione e test di integrazione.
+- GDB: debugging a livello sorgente.
+- Limine: protocollo di boot e bootloader.
 
-## Build stages
+## Fasi della build
 
 ```text
-C and assembly sources
+Sorgenti C e assembly
         |
         v
-Object files
+File oggetto
         |
         v
 kernel.elf
         |
-        +----> debug symbols and map file
+        +----> simboli di debug e map file
         |
         v
-staged boot tree
+albero di boot preparato
         |
         v
-UEFI image
+immagine UEFI
         |
         v
 QEMU
 ```
 
-Each stage must be represented by explicit inputs and outputs. A stage runs only when its inputs change.
+Ogni fase deve avere input e output espliciti. Una fase viene eseguita solo quando cambiano i suoi input.
 
-## Expected commands
+## Comandi previsti
 
-The public interface should remain small:
+L'interfaccia pubblica deve restare piccola:
 
 ```bash
 ./tools/dev setup
@@ -64,47 +64,47 @@ The public interface should remain small:
 ./tools/dev clean
 ```
 
-`tools/dev` is only a thin command dispatcher. It must not reimplement compiler dependency logic.
+`tools/dev` è soltanto un dispatcher sottile. Non deve reimplementare la logica delle dipendenze del compilatore.
 
-Equivalent lower-level commands remain documented:
+I comandi di livello inferiore restano documentati:
 
 ```bash
 meson setup build/debug --cross-file config/x86_64.ini --buildtype=debug
 meson compile -C build/debug
 ```
 
-## Build profiles
+## Profili di build
 
 ### Debug
 
-- debug information;
-- frame pointers;
-- assertions;
-- detailed logging;
-- allocator integrity checks;
-- minimal optimization.
+- informazioni di debug;
+- frame pointer;
+- assertion;
+- logging dettagliato;
+- controlli di integrità degli allocator;
+- ottimizzazione minima.
 
 ### Release
 
-- optimized kernel;
-- reduced logging;
-- separate or preserved symbols for postmortem debugging;
-- no correctness dependency on disabled assertions.
+- kernel ottimizzato;
+- logging ridotto;
+- simboli separati o conservati per il debugging post-mortem;
+- nessuna dipendenza di correttezza da assertion disabilitate.
 
 ### Test
 
-- test registry enabled;
-- deterministic QEMU configuration;
-- machine-readable exit code;
-- optional fault-injection targets.
+- registro dei test abilitato;
+- configurazione QEMU deterministica;
+- codice di uscita leggibile dalla macchina;
+- target opzionali per fault injection.
 
-## Image-generation policy
+## Politica di generazione dell'immagine
 
-Kernel compilation and boot-image construction are separate targets. Recompiling a source file must not repartition or reformat an image unless the kernel ELF actually changed.
+La compilazione del kernel e la costruzione dell'immagine di boot sono target separati. Ricompilare un sorgente non deve ripartizionare o riformattare un'immagine, salvo che `kernel.elf` sia realmente cambiato.
 
-The first release targets UEFI only. Legacy BIOS support is a later, isolated feature.
+La prima release supporta solo UEFI. Il BIOS legacy è una funzionalità successiva e isolata.
 
-The staged boot tree should look like:
+L'albero di boot preparato deve essere simile a:
 
 ```text
 build/debug/sysroot/
@@ -116,28 +116,28 @@ build/debug/sysroot/
         └── BOOTX64.EFI
 ```
 
-## Dependency management
+## Gestione delle dipendenze
 
-External bootloader artifacts must be pinned to a known version. Downloads should be verified with a checksum. The repository should not depend on mutable files installed at paths such as `/opt/limine`.
+Gli artefatti esterni del bootloader devono essere fissati a una versione nota. I download devono essere verificati con checksum. Il repository non deve dipendere da file mutabili installati in percorsi come `/opt/limine`.
 
-Host dependencies are checked by `tools/dev setup`. That command reports missing tools and does not silently install system packages.
+Le dipendenze host vengono controllate da `tools/dev setup`. Il comando segnala gli strumenti mancanti e non installa silenziosamente pacchetti di sistema.
 
-## Container policy
+## Politica dei container
 
-Local development uses the native toolchain for speed. A container image provides a reproducible reference environment for CI and users who prefer isolation.
+Lo sviluppo locale usa la toolchain nativa per velocità. Un'immagine container fornisce un ambiente di riferimento riproducibile per CI e per chi preferisce l'isolamento.
 
-The container must not be rebuilt for each source change. Source directories may be mounted into a previously built development image.
+Il container non deve essere ricostruito a ogni modifica dei sorgenti. Le directory del progetto possono essere montate in un'immagine di sviluppo già costruita.
 
-## Performance expectations
+## Aspettative prestazionali
 
-After the initial configuration:
+Dopo la configurazione iniziale:
 
-- no-op build should complete almost immediately;
-- editing one C file should compile one object and relink;
-- documentation changes should not rebuild the kernel;
-- QEMU launch should not trigger a clean build;
-- test selection should avoid running unrelated suites.
+- una build senza modifiche deve terminare quasi subito;
+- modificare un file C deve compilare un solo oggetto e rilinkare;
+- le modifiche alla documentazione non devono ricostruire il kernel;
+- l'avvio di QEMU non deve forzare una clean build;
+- la selezione dei test deve evitare suite non correlate.
 
-## Build observability
+## Osservabilità della build
 
-The build should be inspectable with standard Meson and Ninja tooling. Custom scripts must print the exact failed command and return its exit status unchanged.
+La build deve essere ispezionabile con gli strumenti standard di Meson e Ninja. Gli script personalizzati devono stampare il comando esatto fallito e restituirne invariato il codice di uscita.

--- a/docs/new-project/C23_POLICY.md
+++ b/docs/new-project/C23_POLICY.md
@@ -1,27 +1,27 @@
-# C23 Language Policy
+# Politica del linguaggio C23
 
 ## Standard
 
-The kernel is written in ISO C23 and compiled in freestanding mode.
+Il kernel è scritto in ISO C23 e compilato in modalità freestanding.
 
-Primary compiler mode:
+Modalità principale del compilatore:
 
 ```text
 -std=c23 -ffreestanding
 ```
 
-GNU language modes such as `gnu23` are not the default. Compiler extensions may be used only when they solve a concrete low-level requirement and are hidden behind project macros or architecture-specific interfaces.
+Le modalità GNU come `gnu23` non sono il default. Le estensioni del compilatore possono essere usate solo quando risolvono un requisito concreto di basso livello e devono essere nascoste dietro macro del progetto o interfacce specifiche dell'architettura.
 
-## Compiler policy
+## Politica del compilatore
 
-- Clang is the primary compiler.
-- LLD is the primary linker.
-- A secondary GCC build should be added to CI when the initial toolchain is stable.
-- The minimum supported compiler version must be documented and pinned in CI.
+- Clang è il compilatore principale.
+- LLD è il linker principale.
+- Una build secondaria con GCC deve essere aggiunta alla CI quando la toolchain iniziale è stabile.
+- La versione minima supportata del compilatore deve essere documentata e fissata nella CI.
 
-## Useful C23 features
+## Funzionalità C23 utili
 
-The project may use modern features where they improve clarity or static verification:
+Il progetto può usare funzionalità moderne quando migliorano chiarezza o verifica statica:
 
 ```c
 static_assert(sizeof(struct interrupt_frame) == EXPECTED_SIZE);
@@ -35,11 +35,11 @@ pmm_status_t pmm_alloc_page(paddr_t *out_page);
 struct page *page = nullptr;
 ```
 
-Fixed underlying types for enumerations may be used for hardware flags and ABI values when compiler support is verified.
+I tipi sottostanti fissi per le enumerazioni possono essere usati per flag hardware e valori ABI quando il supporto del compilatore è stato verificato.
 
-## Freestanding environment
+## Ambiente freestanding
 
-Selecting C23 does not provide a hosted C library. The project may use compiler-provided freestanding headers where supported, including:
+Selezionare C23 non fornisce una libreria C hosted. Il progetto può usare gli header freestanding forniti dal compilatore, quando supportati, tra cui:
 
 - `<stddef.h>`
 - `<stdint.h>`
@@ -48,20 +48,20 @@ Selecting C23 does not provide a hosted C library. The project may use compiler-
 - `<stdalign.h>`
 - `<limits.h>`
 
-The kernel provides the runtime functions it requires, such as:
+Il kernel implementa le funzioni runtime che gli servono, come:
 
 - `memcpy`
 - `memmove`
 - `memset`
 - `memcmp`
 - `strlen`
-- formatting and logging primitives
+- primitive di formattazione e logging
 
-No kernel source may accidentally depend on the host libc.
+Nessun sorgente del kernel deve dipendere accidentalmente dalla libc dell'host.
 
-## Type policy
+## Politica dei tipi
 
-Prefer explicit standard-width types:
+Preferire tipi standard a larghezza esplicita:
 
 ```c
 uint8_t
@@ -72,18 +72,18 @@ uintptr_t
 size_t
 ```
 
-Project-specific semantic aliases are encouraged where they prevent address-space confusion:
+Sono incoraggiati alias semantici specifici del progetto quando prevengono confusione tra spazi di indirizzamento:
 
 ```c
 typedef uintptr_t paddr_t;
 typedef uintptr_t vaddr_t;
 ```
 
-Avoid globally defined ambiguous aliases such as `u8`, `u32` and `ulong` in educational-facing APIs.
+Evitare alias globali ambigui come `u8`, `u32` e `ulong` nelle API rivolte alla didattica.
 
-## Compiler abstraction
+## Astrazione del compilatore
 
-Compiler-specific syntax belongs in one small header, for example:
+La sintassi specifica del compilatore deve risiedere in un piccolo header, per esempio:
 
 ```c
 #pragma once
@@ -93,15 +93,15 @@ Compiler-specific syntax belongs in one small header, for example:
 #define K_ALIGNED(value) __attribute__((aligned(value)))
 #define K_SECTION(name) __attribute__((section(name)))
 #else
-#error "Unsupported compiler"
+#error "Compilatore non supportato"
 #endif
 ```
 
-Architecture headers may use these wrappers but should not duplicate raw attributes throughout the source tree.
+Gli header dell'architettura possono usare questi wrapper, ma non devono duplicare attributi grezzi in tutto l'albero dei sorgenti.
 
-## Warning policy
+## Politica dei warning
 
-Debug and CI builds should begin with a strict warning set:
+Le build debug e CI devono partire da un insieme rigoroso di warning:
 
 ```text
 -Wall
@@ -115,36 +115,36 @@ Debug and CI builds should begin with a strict warning set:
 -Wstrict-prototypes
 ```
 
-Warnings that are unsuitable for a specific low-level file should be disabled narrowly, with a comment explaining why. Global suppression is discouraged.
+I warning non adatti a uno specifico file low-level devono essere disabilitati nel punto più ristretto possibile, con un commento che ne spieghi il motivo. Le soppressioni globali sono sconsigliate.
 
-## Style principles
+## Principi di stile
 
-- Functions and variables use `snake_case`.
-- Types use descriptive names ending in `_t` only for project typedefs where appropriate.
-- Constants and macros use `UPPER_SNAKE_CASE`.
-- Public headers expose minimal APIs.
-- Functions return typed status values for recoverable failures.
-- Output parameters are validated.
-- Pointer arithmetic is isolated and commented.
-- Integer casts must make truncation or reinterpretation explicit.
+- Funzioni e variabili usano `snake_case`.
+- I tipi usano nomi descrittivi con suffisso `_t` solo per typedef del progetto, quando appropriato.
+- Costanti e macro usano `UPPER_SNAKE_CASE`.
+- Gli header pubblici espongono API minime.
+- Le funzioni restituiscono valori di stato tipizzati per gli errori recuperabili.
+- I parametri di output vengono validati.
+- L'aritmetica dei puntatori è isolata e commentata.
+- I cast interi devono rendere esplicita la troncatura o la reinterpretazione.
 
-## Assembly boundary
+## Confine con l'assembly
 
-Assembly is kept in separate `.S` files when possible. Inline assembly is reserved for small CPU primitives where the constraints are reviewed carefully.
+L'assembly viene mantenuto in file `.S` separati quando possibile. L'inline assembly è riservato a piccole primitive CPU i cui constraint siano stati revisionati con attenzione.
 
-Every assembly interface must document:
+Ogni interfaccia assembly deve documentare:
 
-- inputs and outputs;
-- clobbered registers;
-- stack layout;
+- input e output;
+- registri clobbered;
+- layout dello stack;
 - calling convention;
-- alignment assumptions.
+- requisiti di allineamento.
 
-## Feature adoption rule
+## Regola di adozione delle funzionalità
 
-The project uses C23 to improve correctness and readability, not to maximize novelty. A language feature is adopted only when:
+Il progetto usa C23 per migliorare correttezza e leggibilità, non per massimizzare la novità. Una funzionalità del linguaggio viene adottata solo quando:
 
-1. it is supported by the pinned primary compiler;
-2. it has a clear benefit;
-3. it can be explained to the audience;
-4. it does not obscure the generated machine-level behavior relevant to the lesson.
+1. è supportata dal compilatore principale fissato;
+2. offre un beneficio chiaro;
+3. può essere spiegata al pubblico;
+4. non nasconde il comportamento a livello macchina rilevante per la lezione.

--- a/docs/new-project/C23_POLICY.md
+++ b/docs/new-project/C23_POLICY.md
@@ -1,0 +1,150 @@
+# C23 Language Policy
+
+## Standard
+
+The kernel is written in ISO C23 and compiled in freestanding mode.
+
+Primary compiler mode:
+
+```text
+-std=c23 -ffreestanding
+```
+
+GNU language modes such as `gnu23` are not the default. Compiler extensions may be used only when they solve a concrete low-level requirement and are hidden behind project macros or architecture-specific interfaces.
+
+## Compiler policy
+
+- Clang is the primary compiler.
+- LLD is the primary linker.
+- A secondary GCC build should be added to CI when the initial toolchain is stable.
+- The minimum supported compiler version must be documented and pinned in CI.
+
+## Useful C23 features
+
+The project may use modern features where they improve clarity or static verification:
+
+```c
+static_assert(sizeof(struct interrupt_frame) == EXPECTED_SIZE);
+
+[[noreturn]]
+void panic(const char *message);
+
+[[nodiscard]]
+pmm_status_t pmm_alloc_page(paddr_t *out_page);
+
+struct page *page = nullptr;
+```
+
+Fixed underlying types for enumerations may be used for hardware flags and ABI values when compiler support is verified.
+
+## Freestanding environment
+
+Selecting C23 does not provide a hosted C library. The project may use compiler-provided freestanding headers where supported, including:
+
+- `<stddef.h>`
+- `<stdint.h>`
+- `<stdbool.h>`
+- `<stdarg.h>`
+- `<stdalign.h>`
+- `<limits.h>`
+
+The kernel provides the runtime functions it requires, such as:
+
+- `memcpy`
+- `memmove`
+- `memset`
+- `memcmp`
+- `strlen`
+- formatting and logging primitives
+
+No kernel source may accidentally depend on the host libc.
+
+## Type policy
+
+Prefer explicit standard-width types:
+
+```c
+uint8_t
+uint16_t
+uint32_t
+uint64_t
+uintptr_t
+size_t
+```
+
+Project-specific semantic aliases are encouraged where they prevent address-space confusion:
+
+```c
+typedef uintptr_t paddr_t;
+typedef uintptr_t vaddr_t;
+```
+
+Avoid globally defined ambiguous aliases such as `u8`, `u32` and `ulong` in educational-facing APIs.
+
+## Compiler abstraction
+
+Compiler-specific syntax belongs in one small header, for example:
+
+```c
+#pragma once
+
+#if defined(__clang__) || defined(__GNUC__)
+#define K_PACKED __attribute__((packed))
+#define K_ALIGNED(value) __attribute__((aligned(value)))
+#define K_SECTION(name) __attribute__((section(name)))
+#else
+#error "Unsupported compiler"
+#endif
+```
+
+Architecture headers may use these wrappers but should not duplicate raw attributes throughout the source tree.
+
+## Warning policy
+
+Debug and CI builds should begin with a strict warning set:
+
+```text
+-Wall
+-Wextra
+-Wpedantic
+-Werror
+-Wconversion
+-Wshadow
+-Wundef
+-Wmissing-prototypes
+-Wstrict-prototypes
+```
+
+Warnings that are unsuitable for a specific low-level file should be disabled narrowly, with a comment explaining why. Global suppression is discouraged.
+
+## Style principles
+
+- Functions and variables use `snake_case`.
+- Types use descriptive names ending in `_t` only for project typedefs where appropriate.
+- Constants and macros use `UPPER_SNAKE_CASE`.
+- Public headers expose minimal APIs.
+- Functions return typed status values for recoverable failures.
+- Output parameters are validated.
+- Pointer arithmetic is isolated and commented.
+- Integer casts must make truncation or reinterpretation explicit.
+
+## Assembly boundary
+
+Assembly is kept in separate `.S` files when possible. Inline assembly is reserved for small CPU primitives where the constraints are reviewed carefully.
+
+Every assembly interface must document:
+
+- inputs and outputs;
+- clobbered registers;
+- stack layout;
+- calling convention;
+- alignment assumptions.
+
+## Feature adoption rule
+
+The project uses C23 to improve correctness and readability, not to maximize novelty. A language feature is adopted only when:
+
+1. it is supported by the pinned primary compiler;
+2. it has a clear benefit;
+3. it can be explained to the audience;
+4. it does not obscure the generated machine-level behavior relevant to the lesson.

--- a/docs/new-project/DECISIONS.md
+++ b/docs/new-project/DECISIONS.md
@@ -1,0 +1,166 @@
+# Architecture Decision Records
+
+This document lists the initial project decisions. As the project grows, each important decision may be moved into an individual file under `docs/adr/`.
+
+## ADR-001 — Start a separate operating-system project
+
+Status: Accepted
+
+Decision:
+
+The new project is not a continuation or rewrite-in-place of Zone OS. Zone OS remains available as a record of previous experience. The new system begins from an empty repository with newly documented constraints.
+
+Reasoning:
+
+- avoids inheriting accidental complexity;
+- allows the build and teaching sequence to be designed from the beginning;
+- preserves Zone OS as a historical and educational reference;
+- prevents compatibility requirements with unfinished interfaces.
+
+## ADR-002 — Target x86_64 only initially
+
+Status: Accepted
+
+Decision:
+
+The initial kernel supports x86_64 only.
+
+Reasoning:
+
+Architecture abstraction is useful only after the real requirements of one implementation are understood. Premature multi-architecture interfaces can hide hardware behavior and complicate the educational path.
+
+## ADR-003 — Use a modular monolithic kernel
+
+Status: Accepted
+
+Decision:
+
+The first system uses a monolithic address space with internal module boundaries.
+
+Reasoning:
+
+This provides a direct path to memory management, scheduling and user space without introducing IPC and service isolation before the fundamentals are stable. A future microkernel experiment remains possible but is not an initial constraint.
+
+## ADR-004 — Use Limine and begin with UEFI
+
+Status: Accepted
+
+Decision:
+
+Limine provides the boot protocol and initial loading environment. The first supported firmware path is UEFI.
+
+Reasoning:
+
+- avoids writing a bootloader before writing the kernel;
+- provides a modern and documented loading environment;
+- reduces initial image-generation complexity;
+- allows legacy BIOS support to be taught later as a separate topic.
+
+## ADR-005 — Use ISO C23 in freestanding mode
+
+Status: Accepted
+
+Decision:
+
+Kernel code uses `-std=c23` and `-ffreestanding`, with Clang as the primary compiler.
+
+Reasoning:
+
+C23 offers clearer attributes, static checks and modern language facilities while preserving a close relationship with the generated machine code. GNU extensions are isolated and used only when required.
+
+## ADR-006 — Use Meson and Ninja
+
+Status: Accepted
+
+Decision:
+
+Meson describes the build and Ninja executes it incrementally.
+
+Reasoning:
+
+The previous project relied on shell scripts, repeated source discovery and clean rebuilds. The new system requires explicit dependency tracking, fast incremental builds, multiple profiles and a workflow that remains understandable in videos.
+
+## ADR-007 — Keep Docker optional during development
+
+Status: Accepted
+
+Decision:
+
+Native tools are the preferred development path. A pinned container image provides reproducibility for CI and optional isolated development.
+
+Reasoning:
+
+Rebuilding or invoking an emulated x86_64 container for every source change creates unnecessary latency, especially on ARM hosts. Reproducibility remains important but should not make the local edit-build-run cycle inefficient.
+
+## ADR-008 — Use serial output before framebuffer output
+
+Status: Accepted
+
+Decision:
+
+The serial console is the first and primary diagnostic channel.
+
+Reasoning:
+
+Serial output is simple, deterministic, capturable by CI and available before graphics initialization. Framebuffer output is introduced later as a driver and presentation layer.
+
+## ADR-009 — Build diagnostics before advanced memory management
+
+Status: Accepted
+
+Decision:
+
+Panic handling, exception reporting, register dumps and debugger integration precede custom paging and dynamic allocation.
+
+Reasoning:
+
+Complex kernel subsystems are difficult to develop without trustworthy failure information. Diagnostic capability is treated as infrastructure, not polish.
+
+## ADR-010 — Prefer simple allocators first
+
+Status: Accepted
+
+Decision:
+
+The physical allocator begins as a bitmap. The kernel heap begins with an early bump allocator followed by a simple page-backed free-list allocator.
+
+Reasoning:
+
+Buddy and slab allocators are valuable but add metadata and invariants before the project has demonstrated a need for them. They may be introduced later with measurements and tests.
+
+## ADR-011 — Make tests part of each milestone
+
+Status: Accepted
+
+Decision:
+
+Every milestone defines observable completion criteria and automated tests where practical.
+
+Reasoning:
+
+The repository supports both long-term maintenance and a teaching series. Reproducible tests let viewers distinguish implementation errors from environment problems and prevent later episodes from silently breaking earlier work.
+
+## ADR-012 — Align repository history with the video series
+
+Status: Accepted
+
+Decision:
+
+Each episode has an issue, focused branch, notes, start tag and completion tag.
+
+Reasoning:
+
+A viewer must be able to reproduce the exact starting state, follow the implementation and compare the final result without interpreting unrelated later changes.
+
+## ADR process
+
+A new ADR is required when a decision:
+
+- affects several subsystems;
+- changes a public kernel interface or ABI;
+- changes build or toolchain policy;
+- changes the roadmap materially;
+- introduces a difficult-to-reverse dependency;
+- changes the educational sequence.
+
+Each ADR should contain context, decision, consequences and rejected alternatives.

--- a/docs/new-project/DECISIONS.md
+++ b/docs/new-project/DECISIONS.md
@@ -1,166 +1,166 @@
-# Architecture Decision Records
+# Decisioni architetturali
 
-This document lists the initial project decisions. As the project grows, each important decision may be moved into an individual file under `docs/adr/`.
+Questo documento raccoglie le decisioni iniziali del progetto. Con la crescita del sistema, ogni decisione importante potrà essere spostata in un file dedicato sotto `docs/adr/`.
 
-## ADR-001 — Start a separate operating-system project
+## ADR-001 — Avviare un nuovo progetto di sistema operativo
 
-Status: Accepted
+**Stato:** Accettata
 
-Decision:
+**Decisione:**
 
-The new project is not a continuation or rewrite-in-place of Zone OS. Zone OS remains available as a record of previous experience. The new system begins from an empty repository with newly documented constraints.
+Il nuovo progetto non è una continuazione né una riscrittura nello stesso repository di Zone OS. Zone OS resta disponibile come testimonianza dell’esperienza precedente. Il nuovo sistema parte da un repository vuoto e da vincoli documentati da zero.
 
-Reasoning:
+**Motivazioni:**
 
-- avoids inheriting accidental complexity;
-- allows the build and teaching sequence to be designed from the beginning;
-- preserves Zone OS as a historical and educational reference;
-- prevents compatibility requirements with unfinished interfaces.
+- evita di ereditare complessità accidentale;
+- permette di progettare fin dall’inizio build e percorso didattico;
+- conserva Zone OS come riferimento storico;
+- evita requisiti di compatibilità con interfacce incomplete.
 
-## ADR-002 — Target x86_64 only initially
+## ADR-002 — Supportare inizialmente solo x86_64
 
-Status: Accepted
+**Stato:** Accettata
 
-Decision:
+**Decisione:**
 
-The initial kernel supports x86_64 only.
+Il kernel iniziale supporta solo x86_64 in modalità a 64 bit.
 
-Reasoning:
+**Motivazioni:**
 
-Architecture abstraction is useful only after the real requirements of one implementation are understood. Premature multi-architecture interfaces can hide hardware behavior and complicate the educational path.
+Le astrazioni architetturali sono utili solo dopo aver compreso i requisiti reali di almeno un’implementazione. Interfacce multiarchitettura premature possono nascondere il comportamento hardware e complicare il percorso didattico.
 
-## ADR-003 — Use a modular monolithic kernel
+## ADR-003 — Usare un kernel monolitico modulare
 
-Status: Accepted
+**Stato:** Accettata
 
-Decision:
+**Decisione:**
 
-The first system uses a monolithic address space with internal module boundaries.
+Il primo sistema usa un unico spazio di indirizzamento kernel con confini modulari interni.
 
-Reasoning:
+**Motivazioni:**
 
-This provides a direct path to memory management, scheduling and user space without introducing IPC and service isolation before the fundamentals are stable. A future microkernel experiment remains possible but is not an initial constraint.
+Fornisce un percorso diretto verso memoria, scheduling e user space senza introdurre IPC e isolamento dei servizi prima che le fondamenta siano stabili. Un futuro esperimento microkernel resta possibile, ma non è un vincolo iniziale.
 
-## ADR-004 — Use Limine and begin with UEFI
+## ADR-004 — Usare Limine e iniziare da UEFI
 
-Status: Accepted
+**Stato:** Accettata
 
-Decision:
+**Decisione:**
 
-Limine provides the boot protocol and initial loading environment. The first supported firmware path is UEFI.
+Limine fornisce protocollo di boot e ambiente di caricamento. Il primo percorso firmware supportato è UEFI.
 
-Reasoning:
+**Motivazioni:**
 
-- avoids writing a bootloader before writing the kernel;
-- provides a modern and documented loading environment;
-- reduces initial image-generation complexity;
-- allows legacy BIOS support to be taught later as a separate topic.
+- evita di scrivere un bootloader prima del kernel;
+- offre un ambiente moderno e documentato;
+- riduce la complessità iniziale di generazione delle immagini;
+- consente di trattare BIOS legacy come argomento separato.
 
-## ADR-005 — Use ISO C23 in freestanding mode
+## ADR-005 — Usare ISO C23 in modalità freestanding
 
-Status: Accepted
+**Stato:** Accettata
 
-Decision:
+**Decisione:**
 
-Kernel code uses `-std=c23` and `-ffreestanding`, with Clang as the primary compiler.
+Il codice kernel usa `-std=c23` e `-ffreestanding`, con Clang come compilatore principale.
 
-Reasoning:
+**Motivazioni:**
 
-C23 offers clearer attributes, static checks and modern language facilities while preserving a close relationship with the generated machine code. GNU extensions are isolated and used only when required.
+C23 offre attributi più chiari, verifiche statiche e strumenti moderni mantenendo una relazione stretta con il codice macchina generato. Le estensioni GNU vengono isolate e usate solo quando necessarie.
 
-## ADR-006 — Use Meson and Ninja
+## ADR-006 — Usare Meson e Ninja
 
-Status: Accepted
+**Stato:** Accettata
 
-Decision:
+**Decisione:**
 
-Meson describes the build and Ninja executes it incrementally.
+Meson descrive la build e Ninja la esegue incrementalmente.
 
-Reasoning:
+**Motivazioni:**
 
-The previous project relied on shell scripts, repeated source discovery and clean rebuilds. The new system requires explicit dependency tracking, fast incremental builds, multiple profiles and a workflow that remains understandable in videos.
+Il progetto precedente dipendeva da script shell, scansioni ripetute dei sorgenti e ricompilazioni pulite. Il nuovo sistema richiede dipendenze esplicite, build incrementali rapide, profili multipli e un flusso spiegabile nei video.
 
-## ADR-007 — Keep Docker optional during development
+## ADR-007 — Rendere Docker opzionale nello sviluppo
 
-Status: Accepted
+**Stato:** Accettata
 
-Decision:
+**Decisione:**
 
-Native tools are the preferred development path. A pinned container image provides reproducibility for CI and optional isolated development.
+Gli strumenti nativi sono il percorso di sviluppo preferito. Un’immagine container fissata garantisce riproducibilità in CI e sviluppo isolato opzionale.
 
-Reasoning:
+**Motivazioni:**
 
-Rebuilding or invoking an emulated x86_64 container for every source change creates unnecessary latency, especially on ARM hosts. Reproducibility remains important but should not make the local edit-build-run cycle inefficient.
+Ricostruire o invocare un container x86_64 emulato a ogni modifica introduce latenza inutile, soprattutto su host ARM. La riproducibilità resta importante, ma non deve penalizzare il ciclo modifica-build-run.
 
-## ADR-008 — Use serial output before framebuffer output
+## ADR-008 — Usare la seriale prima del framebuffer
 
-Status: Accepted
+**Stato:** Accettata
 
-Decision:
+**Decisione:**
 
-The serial console is the first and primary diagnostic channel.
+La console seriale è il primo e principale canale diagnostico.
 
-Reasoning:
+**Motivazioni:**
 
-Serial output is simple, deterministic, capturable by CI and available before graphics initialization. Framebuffer output is introduced later as a driver and presentation layer.
+È semplice, deterministica, catturabile dalla CI e disponibile prima dell’inizializzazione grafica. Il framebuffer verrà introdotto successivamente come driver e livello di presentazione.
 
-## ADR-009 — Build diagnostics before advanced memory management
+## ADR-009 — Costruire la diagnostica prima della memoria avanzata
 
-Status: Accepted
+**Stato:** Accettata
 
-Decision:
+**Decisione:**
 
-Panic handling, exception reporting, register dumps and debugger integration precede custom paging and dynamic allocation.
+Panic, eccezioni, dump dei registri e integrazione con il debugger precedono paging personalizzato e allocazione dinamica.
 
-Reasoning:
+**Motivazioni:**
 
-Complex kernel subsystems are difficult to develop without trustworthy failure information. Diagnostic capability is treated as infrastructure, not polish.
+I sottosistemi complessi sono difficili da sviluppare senza informazioni affidabili sui fallimenti. La diagnostica è infrastruttura, non rifinitura.
 
-## ADR-010 — Prefer simple allocators first
+## ADR-010 — Preferire inizialmente allocator semplici
 
-Status: Accepted
+**Stato:** Accettata
 
-Decision:
+**Decisione:**
 
-The physical allocator begins as a bitmap. The kernel heap begins with an early bump allocator followed by a simple page-backed free-list allocator.
+L’allocator fisico parte da una bitmap. L’heap parte da un bump allocator iniziale seguito da una free list sostenuta da pagine.
 
-Reasoning:
+**Motivazioni:**
 
-Buddy and slab allocators are valuable but add metadata and invariants before the project has demonstrated a need for them. They may be introduced later with measurements and tests.
+Buddy e slab sono utili, ma introducono metadati e invarianti prima che il progetto ne dimostri la necessità. Potranno essere aggiunti in seguito con misure e test.
 
-## ADR-011 — Make tests part of each milestone
+## ADR-011 — Integrare i test in ogni milestone
 
-Status: Accepted
+**Stato:** Accettata
 
-Decision:
+**Decisione:**
 
-Every milestone defines observable completion criteria and automated tests where practical.
+Ogni milestone definisce criteri osservabili di completamento e test automatici quando praticabile.
 
-Reasoning:
+**Motivazioni:**
 
-The repository supports both long-term maintenance and a teaching series. Reproducible tests let viewers distinguish implementation errors from environment problems and prevent later episodes from silently breaking earlier work.
+Il repository deve sostenere manutenzione e didattica. Test riproducibili aiutano a distinguere errori di implementazione da problemi ambientali e impediscono agli episodi successivi di rompere silenziosamente quelli precedenti.
 
-## ADR-012 — Align repository history with the video series
+## ADR-012 — Allineare la storia Git alla serie video
 
-Status: Accepted
+**Stato:** Accettata
 
-Decision:
+**Decisione:**
 
-Each episode has an issue, focused branch, notes, start tag and completion tag.
+Ogni episodio possiede issue, branch focalizzato, note, tag iniziale e tag finale.
 
-Reasoning:
+**Motivazioni:**
 
-A viewer must be able to reproduce the exact starting state, follow the implementation and compare the final result without interpreting unrelated later changes.
+Chi segue deve poter riprodurre lo stato iniziale esatto, seguire l’implementazione e confrontare il risultato senza interpretare modifiche successive non correlate.
 
-## ADR process
+## Processo ADR
 
-A new ADR is required when a decision:
+È richiesta una nuova ADR quando una decisione:
 
-- affects several subsystems;
-- changes a public kernel interface or ABI;
-- changes build or toolchain policy;
-- changes the roadmap materially;
-- introduces a difficult-to-reverse dependency;
-- changes the educational sequence.
+- coinvolge più sottosistemi;
+- modifica un’interfaccia pubblica o un’ABI;
+- modifica build o toolchain;
+- cambia significativamente la roadmap;
+- introduce una dipendenza difficile da invertire;
+- cambia l’ordine didattico.
 
-Each ADR should contain context, decision, consequences and rejected alternatives.
+Ogni ADR deve contenere contesto, decisione, conseguenze e alternative scartate.

--- a/docs/new-project/DEVELOPMENT_WORKFLOW.md
+++ b/docs/new-project/DEVELOPMENT_WORKFLOW.md
@@ -1,0 +1,130 @@
+# Development Workflow
+
+## Repository strategy
+
+The new operating system should ultimately live in a separate repository. Until that repository is created, these documents are staged in a dedicated Zone OS branch.
+
+The main development branch remains releasable and each feature is introduced through a focused pull request.
+
+## Branch naming
+
+Recommended prefixes:
+
+```text
+build/
+boot/
+arch/
+mm/
+sched/
+user/
+fs/
+test/
+docs/
+episode/
+```
+
+Examples:
+
+```text
+episode/03-incremental-build
+mm/bitmap-page-allocation
+arch/x86_64-page-fault-handler
+```
+
+## Commit policy
+
+Commits should describe one logical change and use an imperative, subsystem-oriented subject:
+
+```text
+build: add x86_64 Meson cross file
+boot: validate Limine memory-map response
+serial: add COM1 polling output
+mm: reserve bootloader-owned pages
+test: add PMM double-free case
+docs: explain high-half address layout
+```
+
+Avoid commits that mix formatting, refactoring, new behavior and documentation without a strong reason.
+
+## Pull-request completion checklist
+
+Every implementation PR should answer:
+
+- What observable behavior changes?
+- Which invariant or interface is introduced?
+- How was it tested?
+- What failure cases were tested?
+- Does the design documentation need updating?
+- Does this change belong to a YouTube episode?
+
+Recommended checklist:
+
+```markdown
+- [ ] Debug build passes
+- [ ] Release build passes
+- [ ] Host-side tests pass
+- [ ] QEMU tests pass
+- [ ] Documentation updated
+- [ ] No unrelated generated files committed
+- [ ] Episode notes updated when applicable
+```
+
+## Episode workflow
+
+Each episode uses a reproducible start and completion point.
+
+```text
+Issue:   Episode 03 — Incremental kernel build
+Branch:  episode/03-incremental-build
+Tag:     ep03-start
+Tag:     ep03-complete
+Notes:   docs/episodes/03-incremental-build.md
+```
+
+Viewers should be able to run:
+
+```bash
+git checkout ep03-start
+git diff ep03-start ep03-complete
+```
+
+The video may show mistakes and debugging, while the final commit history should remain understandable.
+
+## Definition of done
+
+A feature is complete only when:
+
+1. the code compiles without new warnings;
+2. its expected behavior is observable;
+3. relevant tests pass;
+4. failure behavior is documented;
+5. public APIs are documented;
+6. the corresponding design document is updated;
+7. temporary debug code is removed or intentionally gated.
+
+## Review principles
+
+Reviews should focus on:
+
+- initialization order;
+- ownership and lifetime;
+- integer overflow;
+- physical versus virtual address confusion;
+- interrupt safety;
+- reentrancy;
+- lock ordering;
+- user-pointer validation;
+- behavior during partial initialization;
+- testability and diagnostic quality.
+
+## Generated files
+
+Build artifacts, disk images, dependency caches and downloaded toolchains are not committed unless explicitly required for a release artifact.
+
+The repository should contain checksums and scripts that recreate external dependencies rather than mutable binary copies without provenance.
+
+## Documentation maintenance
+
+Documentation is treated as part of the implementation. Architectural changes update the relevant document in the same PR.
+
+Small local decisions may be documented in code. Decisions that affect multiple modules, the public ABI, the build system or the teaching sequence require an Architecture Decision Record.

--- a/docs/new-project/DEVELOPMENT_WORKFLOW.md
+++ b/docs/new-project/DEVELOPMENT_WORKFLOW.md
@@ -1,14 +1,14 @@
-# Development Workflow
+# Flusso di sviluppo
 
-## Repository strategy
+## Strategia del repository
 
-The new operating system should ultimately live in a separate repository. Until that repository is created, these documents are staged in a dedicated Zone OS branch.
+Il nuovo sistema operativo dovrà vivere in un repository separato. Fino alla sua creazione, questi documenti restano su un branch dedicato di Zone OS.
 
-The main development branch remains releasable and each feature is introduced through a focused pull request.
+Il branch principale deve rimanere rilasciabile e ogni funzionalità viene introdotta tramite una pull request focalizzata.
 
-## Branch naming
+## Nomi dei branch
 
-Recommended prefixes:
+Prefissi consigliati:
 
 ```text
 build/
@@ -23,108 +23,108 @@ docs/
 episode/
 ```
 
-Examples:
+Esempi:
 
 ```text
-episode/03-incremental-build
-mm/bitmap-page-allocation
+episode/03-build-incrementale
+mm/allocazione-pagine-bitmap
 arch/x86_64-page-fault-handler
 ```
 
-## Commit policy
+## Politica dei commit
 
-Commits should describe one logical change and use an imperative, subsystem-oriented subject:
+Ogni commit deve descrivere una singola modifica logica e usare un oggetto imperativo orientato al sottosistema:
 
 ```text
-build: add x86_64 Meson cross file
-boot: validate Limine memory-map response
-serial: add COM1 polling output
-mm: reserve bootloader-owned pages
-test: add PMM double-free case
-docs: explain high-half address layout
+build: aggiungi il cross file Meson x86_64
+boot: valida la risposta della memory map Limine
+serial: aggiungi output polling su COM1
+mm: riserva le pagine possedute dal bootloader
+test: aggiungi il caso PMM double-free
+docs: spiega il layout high-half
 ```
 
-Avoid commits that mix formatting, refactoring, new behavior and documentation without a strong reason.
+Evitare commit che mescolano formattazione, refactoring, nuovo comportamento e documentazione senza una ragione forte.
 
-## Pull-request completion checklist
+## Checklist di completamento delle pull request
 
-Every implementation PR should answer:
+Ogni PR di implementazione deve rispondere a queste domande:
 
-- What observable behavior changes?
-- Which invariant or interface is introduced?
-- How was it tested?
-- What failure cases were tested?
-- Does the design documentation need updating?
-- Does this change belong to a YouTube episode?
+- Quale comportamento osservabile cambia?
+- Quale invariante o interfaccia viene introdotta?
+- Come è stata testata?
+- Quali casi di errore sono stati provati?
+- La documentazione di progetto deve essere aggiornata?
+- La modifica appartiene a un episodio YouTube?
 
-Recommended checklist:
+Checklist consigliata:
 
 ```markdown
-- [ ] Debug build passes
-- [ ] Release build passes
-- [ ] Host-side tests pass
-- [ ] QEMU tests pass
-- [ ] Documentation updated
-- [ ] No unrelated generated files committed
-- [ ] Episode notes updated when applicable
+- [ ] Build debug completata
+- [ ] Build release completata
+- [ ] Test host completati
+- [ ] Test QEMU completati
+- [ ] Documentazione aggiornata
+- [ ] Nessun artefatto generato non correlato incluso
+- [ ] Note dell'episodio aggiornate, quando applicabile
 ```
 
-## Episode workflow
+## Flusso degli episodi
 
-Each episode uses a reproducible start and completion point.
+Ogni episodio usa un punto iniziale e finale riproducibile.
 
 ```text
-Issue:   Episode 03 — Incremental kernel build
-Branch:  episode/03-incremental-build
+Issue:   Episodio 03 — Build incrementale del kernel
+Branch:  episode/03-build-incrementale
 Tag:     ep03-start
 Tag:     ep03-complete
-Notes:   docs/episodes/03-incremental-build.md
+Note:    docs/episodes/03-build-incrementale.md
 ```
 
-Viewers should be able to run:
+Chi segue deve poter eseguire:
 
 ```bash
 git checkout ep03-start
 git diff ep03-start ep03-complete
 ```
 
-The video may show mistakes and debugging, while the final commit history should remain understandable.
+Il video può mostrare errori e debugging; la cronologia finale deve comunque restare comprensibile.
 
-## Definition of done
+## Definizione di completato
 
-A feature is complete only when:
+Una funzionalità è completa solo quando:
 
-1. the code compiles without new warnings;
-2. its expected behavior is observable;
-3. relevant tests pass;
-4. failure behavior is documented;
-5. public APIs are documented;
-6. the corresponding design document is updated;
-7. temporary debug code is removed or intentionally gated.
+1. compila senza nuovi warning;
+2. il comportamento atteso è osservabile;
+3. i test rilevanti passano;
+4. il comportamento in caso di errore è documentato;
+5. le API pubbliche sono documentate;
+6. il documento di design corrispondente è aggiornato;
+7. il codice di debug temporaneo è rimosso o protetto da un’opzione esplicita.
 
-## Review principles
+## Principi di revisione
 
-Reviews should focus on:
+Le review devono concentrarsi su:
 
-- initialization order;
-- ownership and lifetime;
-- integer overflow;
-- physical versus virtual address confusion;
-- interrupt safety;
-- reentrancy;
-- lock ordering;
-- user-pointer validation;
-- behavior during partial initialization;
-- testability and diagnostic quality.
+- ordine di inizializzazione;
+- proprietà e durata degli oggetti;
+- overflow interi;
+- confusione tra indirizzi fisici e virtuali;
+- sicurezza rispetto agli interrupt;
+- rientranza;
+- ordine dei lock;
+- validazione dei puntatori utente;
+- comportamento durante inizializzazioni parziali;
+- testabilità e qualità della diagnostica.
 
-## Generated files
+## File generati
 
-Build artifacts, disk images, dependency caches and downloaded toolchains are not committed unless explicitly required for a release artifact.
+Artefatti di build, immagini disco, cache e toolchain scaricate non vengono versionati, salvo espliciti artefatti di release.
 
-The repository should contain checksums and scripts that recreate external dependencies rather than mutable binary copies without provenance.
+Il repository deve contenere checksum e strumenti per ricreare le dipendenze esterne, non copie binarie mutevoli prive di provenienza.
 
-## Documentation maintenance
+## Manutenzione della documentazione
 
-Documentation is treated as part of the implementation. Architectural changes update the relevant document in the same PR.
+La documentazione fa parte dell’implementazione. Le modifiche architetturali aggiornano il documento pertinente nella stessa PR.
 
-Small local decisions may be documented in code. Decisions that affect multiple modules, the public ABI, the build system or the teaching sequence require an Architecture Decision Record.
+Le decisioni locali possono essere commentate nel codice. Le decisioni che coinvolgono più moduli, ABI pubblica, build system o percorso didattico richiedono una Architecture Decision Record.

--- a/docs/new-project/HYBRID_KERNEL_STRATEGY.md
+++ b/docs/new-project/HYBRID_KERNEL_STRATEGY.md
@@ -1,0 +1,319 @@
+# Strategia del kernel ibrido evolutivo
+
+## Decisione
+
+Il progetto adotta un'architettura **ibrida evolutiva**.
+
+La prima implementazione sarà un kernel monolitico modulare, perché permette di raggiungere rapidamente boot, diagnostica, memoria, scheduler e user space. Fin dall'inizio, però, i sottosistemi saranno separati da confini espliciti, contratti piccoli, ownership documentata e strutture non condivise direttamente.
+
+L'obiettivo non è fingere di avere un microkernel prima di costruire l'infrastruttura necessaria. L'obiettivo è rendere possibile spostare progressivamente driver, filesystem e altri servizi in user space senza una riscrittura completa.
+
+## Principio guida
+
+> Implementare localmente oggi, progettare il contratto come se domani potesse attraversare un confine IPC.
+
+Questo non significa serializzare ogni chiamata fin dall'inizio. Significa evitare dipendenze che renderebbero impossibile introdurre quel confine in futuro.
+
+## Fasi evolutive
+
+### Fase A — Kernel monolitico modulare
+
+I sottosistemi vengono eseguiti nello spazio del kernel, ma restano separati:
+
+```text
+Kernel
+├── core
+├── mm
+├── scheduler
+├── IPC
+├── VFS
+├── filesystem
+├── driver
+└── networking
+```
+
+Caratteristiche:
+
+- chiamate dirette tra moduli;
+- un solo spazio privilegiato;
+- debug semplice;
+- iterazione rapida;
+- contratti già compatibili con handle e messaggi.
+
+### Fase B — Kernel ibrido
+
+I servizi selezionati possono essere eseguiti localmente oppure tramite un proxy IPC:
+
+```text
+Client kernel/user
+       |
+       v
+Interfaccia del servizio
+       |
+       +--> backend locale nel kernel
+       |
+       +--> proxy IPC verso server user space
+```
+
+La scelta del backend non deve cambiare la semantica pubblica del servizio.
+
+### Fase C — Servizi user space
+
+Filesystem, driver o network stack possono diventare server isolati:
+
+```text
+Applicazione
+    |
+    v
+Filesystem server
+    |
+    v
+Block-device server
+    |
+    v
+Microkernel core / kernel ibrido
+```
+
+Il kernel mantiene i meccanismi essenziali:
+
+- scheduling;
+- address space;
+- IPC;
+- gestione delle capability o degli handle;
+- consegna degli interrupt;
+- mapping e condivisione controllata della memoria;
+- lifecycle dei task.
+
+## Confini obbligatori fin dall'inizio
+
+### Strutture private
+
+Ogni sottosistema possiede le proprie strutture interne. Gli altri moduli non possono accedere direttamente ai campi privati.
+
+```c
+struct vfs_node;
+struct process;
+struct address_space;
+struct block_device;
+```
+
+Gli oggetti vengono esposti come tipi opachi negli header pubblici.
+
+### Handle invece di puntatori trasferibili
+
+Le API che potrebbero attraversare un futuro confine di processo non devono dipendere da puntatori interni.
+
+```c
+typedef struct {
+    uint64_t value;
+} object_handle_t;
+```
+
+Un puntatore può essere usato internamente al backend locale, ma non deve diventare parte del protocollo pubblico.
+
+### Ownership esplicita
+
+Per ogni risorsa devono essere documentati:
+
+- proprietario;
+- lifetime;
+- operazione di rilascio;
+- comportamento in caso di crash;
+- possibilità di trasferimento o condivisione;
+- regole di concorrenza.
+
+### Errori serializzabili
+
+Gli errori pubblici devono essere valori stabili, non indirizzi, stringhe statiche o codici dipendenti dal backend.
+
+```c
+enum service_status {
+    SERVICE_OK,
+    SERVICE_INVALID_ARGUMENT,
+    SERVICE_NOT_FOUND,
+    SERVICE_PERMISSION_DENIED,
+    SERVICE_UNAVAILABLE,
+    SERVICE_IO_ERROR,
+};
+```
+
+### Buffer descritti esplicitamente
+
+Evitare API che assumono memoria condivisa implicita. Un buffer pubblico deve avere indirizzo, dimensione, direzione e ownership definiti.
+
+Per IPC, i trasferimenti potranno usare:
+
+- copia per messaggi piccoli;
+- pagine condivise per dati grandi;
+- trasferimento temporaneo di ownership;
+- mapping read-only quando sufficiente.
+
+## Regole per le API
+
+Un'interfaccia candidata a diventare remota deve:
+
+- usare tipi a dimensione stabile;
+- non contenere puntatori interni;
+- non dipendere dal layout delle strutture C private;
+- definire timeout e cancellazione quando applicabili;
+- descrivere gli errori parziali;
+- evitare callback arbitrarie attraverso il confine;
+- rendere esplicita la sincronia della chiamata;
+- poter essere testata con un backend fake host-side.
+
+## IPC come fondazione, non come dettaglio tardivo
+
+L'IPC viene introdotto prima del filesystem persistente e prima di spostare driver in user space.
+
+Primitive iniziali candidate:
+
+```text
+endpoint_create
+send
+receive
+call
+reply
+notify
+handle_transfer
+shared_memory_create
+shared_memory_map
+```
+
+La prima implementazione può essere semplice e sincrona. Ottimizzazioni come fast path, zero-copy e priority inheritance vengono introdotte solo dopo aver misurato i colli di bottiglia.
+
+## Scheduler e IPC
+
+Lo scheduler deve conoscere gli stati di attesa IPC senza conoscere il protocollo dei servizi.
+
+Stati possibili:
+
+```text
+READY
+RUNNING
+BLOCKED_IPC_SEND
+BLOCKED_IPC_RECEIVE
+BLOCKED_REPLY
+BLOCKED_EVENT
+TERMINATED
+```
+
+Devono essere studiati e testati:
+
+- deadlock;
+- starvation;
+- inversione di priorità;
+- cancellazione di una richiesta;
+- morte del server mentre esiste un client bloccato.
+
+## VFS e filesystem
+
+Il VFS definisce semantica e namespace. Il filesystem è un backend.
+
+Prima fase:
+
+```text
+VFS -> backend initramfs nel kernel
+```
+
+Fase ibrida:
+
+```text
+VFS -> adapter locale
+VFS -> proxy IPC filesystem server
+```
+
+Le API pubbliche devono usare handle di file, offset e buffer espliciti. Non devono restituire puntatori a vnode interni.
+
+## Driver
+
+I driver iniziali possono restare nel kernel, ma devono implementare interfacce orientate alle capacità:
+
+- block device;
+- character device;
+- network device;
+- clock source;
+- interrupt source;
+- framebuffer.
+
+Un futuro driver server riceverà accesso soltanto alle risorse necessarie:
+
+- regioni MMIO;
+- porte IO, quando applicabile;
+- interrupt assegnati;
+- canali DMA controllati;
+- endpoint IPC.
+
+## Service manager
+
+Quando compaiono i primi server user space servirà un service manager responsabile di:
+
+- bootstrap dei servizi;
+- registrazione dei nomi;
+- distribuzione degli handle;
+- dipendenze tra servizi;
+- restart;
+- health state;
+- policy di recovery.
+
+Il service discovery non deve essere integrato nel microkernel core.
+
+## Criteri per spostare un modulo in user space
+
+Un sottosistema è candidato quando:
+
+- la sua interfaccia è stabile;
+- può essere rappresentato tramite messaggi e handle;
+- i buffer hanno ownership chiara;
+- esistono test del backend locale;
+- esistono test del proxy IPC;
+- il costo dei context switch è accettabile;
+- l'isolamento offre un beneficio concreto;
+- è definito il comportamento in caso di crash del server.
+
+## Ordine consigliato di estrazione
+
+1. servizio di logging non critico;
+2. filesystem initramfs o tmpfs sperimentale;
+3. driver semplice e non essenziale;
+4. block service;
+5. filesystem persistente;
+6. network stack;
+7. driver più complessi.
+
+PMM, VMM di basso livello, scheduler, interrupt core e primitive IPC rimangono inizialmente nel kernel.
+
+## Test della capacità di refactoring
+
+Per ogni servizio candidato devono esistere due implementazioni:
+
+```text
+backend_local
+backend_ipc_proxy
+```
+
+La stessa suite di test contrattuale deve essere eseguibile contro entrambi.
+
+Checklist:
+
+- [ ] Nessun client include header privati del backend.
+- [ ] Nessun protocollo contiene puntatori.
+- [ ] Gli errori sono identici tra backend locale e remoto.
+- [ ] Il backend remoto gestisce la morte del server.
+- [ ] I test verificano messaggi malformati.
+- [ ] I limiti delle dimensioni sono controllati.
+- [ ] Ownership e rilascio degli handle sono verificati.
+- [ ] Il passaggio locale/remoto non cambia la semantica osservabile.
+
+## Non obiettivi iniziali
+
+Non implementeremo subito:
+
+- un capability system completo e formale;
+- IPC zero-copy generalizzato;
+- driver interamente in user space;
+- service restart trasparente;
+- distributed system semantics;
+- compatibilità POSIX completa;
+- separazione di ogni singolo sottosistema.
+
+La priorità resta costruire un sistema funzionante e osservabile, preservando una direzione evolutiva reale.

--- a/docs/new-project/MILESTONES_DETAILED.md
+++ b/docs/new-project/MILESTONES_DETAILED.md
@@ -1,255 +1,166 @@
-# Detailed Milestones and Completion Checklists
+# Milestone dettagliate e checklist di completamento
 
-This document turns the high-level roadmap into executable project milestones.
+Questo documento trasforma la roadmap generale in milestone operative. Il primo target è **x86_64 a 64 bit**, ma i contratti visibili al kernel devono evitare assunzioni architetturali non necessarie.
 
-The initial implementation target is **64-bit x86 (`x86_64`)**, but kernel-facing contracts should avoid unnecessary architecture assumptions. Platform-specific details belong behind explicit architecture interfaces.
+## Regole comuni
 
-## Milestone rules
+Ogni milestone è completa solo quando:
 
-Every milestone must satisfy all of these rules before it is considered complete:
-
-- [ ] The result is observable in QEMU or through a host-side test.
-- [ ] Failure paths are deliberately exercised.
-- [ ] Public interfaces are documented.
-- [ ] Architecture-specific code is isolated under `kernel/arch/x86_64/`.
-- [ ] Generic kernel code does not directly access x86 registers, ports or descriptor tables.
-- [ ] Debug and release builds compile without warnings.
-- [ ] The CI pipeline executes the relevant tests.
-- [ ] The documentation and architecture diagrams are updated.
-- [ ] The milestone ends with a reproducible Git tag.
-- [ ] The corresponding YouTube episode notes include start and completion references.
+- [ ] il risultato è osservabile in QEMU o con un test host-side;
+- [ ] i percorsi di errore vengono provocati intenzionalmente;
+- [ ] le interfacce pubbliche sono documentate;
+- [ ] il codice specifico resta sotto `kernel/arch/x86_64/`;
+- [ ] il codice generico non accede direttamente a registri, porte o descriptor table x86;
+- [ ] build debug e release compilano senza warning;
+- [ ] la CI esegue i test rilevanti;
+- [ ] documentazione e diagrammi sono aggiornati;
+- [ ] viene creato un tag Git riproducibile;
+- [ ] le note dell’episodio indicano stato iniziale e finale.
 
 ---
 
-# M0 — Reproducible 64-bit development workspace
+# M0 — Workspace di sviluppo a 64 bit riproducibile
 
-## Goal
+## Obiettivo
 
-Create a fast, understandable and reproducible workspace for a freestanding 64-bit kernel.
+Creare un ambiente rapido, comprensibile e riproducibile per un kernel freestanding a 64 bit.
 
-## Architecture-neutral contract
+## Contratto indipendente dall’architettura
 
-The build system must model the target platform through configuration rather than hard-coding x86 commands across scripts.
+La build descrive tramite configurazione: architettura target, word size, compilatore, linker, sorgenti di piattaforma, emulatore, firmware, protocollo di boot e trasporto di debug.
 
-Expected concepts:
+## Implementazione x86_64
 
-- target architecture;
-- target machine word size;
-- compiler and linker;
-- platform sources;
-- emulator backend;
-- firmware and boot protocol;
-- debug transport.
+Clang, LLD, Meson, Ninja, QEMU `q35`, UEFI, GDB remoto e terminale seriale.
 
-## x86_64 implementation
+## Deliverable
 
-- Clang with an x86_64 freestanding target;
-- LLD linker;
-- Meson configuration;
-- Ninja incremental build;
-- QEMU `q35` machine;
-- UEFI firmware;
-- GDB remote debugging;
-- serial terminal output.
+- [ ] `meson.build` principale;
+- [ ] opzioni Meson per diagnostica e test;
+- [ ] `config/x86_64.ini`;
+- [ ] flag di compilazione e link espliciti;
+- [ ] profili debug e release;
+- [ ] controllo delle dipendenze;
+- [ ] wrapper `tools/dev` sottile;
+- [ ] launcher QEMU e GDB;
+- [ ] CI di configurazione e build;
+- [ ] versioni supportate documentate;
+- [ ] Docker non obbligatorio nel ciclo locale;
+- [ ] container opzionale e riproducibile.
 
-## Deliverables
+## Verifica
 
-- [ ] Root `meson.build`.
-- [ ] `meson_options.txt` for debug features and kernel tests.
-- [ ] `config/x86_64.ini` cross file.
-- [ ] Explicit compiler and linker flags.
-- [ ] Debug and release build profiles.
-- [ ] Dependency checking command.
-- [ ] `tools/dev` command wrapper.
-- [ ] QEMU launcher.
-- [ ] GDB launcher and initial command file.
-- [ ] CI workflow for configuration and compilation.
-- [ ] Pinned tool versions or documented supported ranges.
-- [ ] No mandatory Docker dependency for the local edit-build-run cycle.
-- [ ] Optional container image for reproducibility and CI.
+- [ ] un clone pulito si configura con un comando;
+- [ ] la build non modifica i sorgenti;
+- [ ] una modifica C ricompila una sola translation unit;
+- [ ] una modifica a un header ricompila solo i dipendenti;
+- [ ] una build no-op non compila nulla;
+- [ ] debug e release possono coesistere;
+- [ ] gli errori mostrano il comando fallito;
+- [ ] viene generato `compile_commands.json`.
 
-## Verification checklist
+## Criterio d’uscita
 
-- [ ] A clean clone configures with one documented command.
-- [ ] The source tree remains unchanged after a build.
-- [ ] Touching one C file recompiles only one translation unit and relinks.
-- [ ] Touching one header recompiles only dependent translation units.
-- [ ] A no-op rebuild performs no compilation.
-- [ ] Parallel builds succeed.
-- [ ] Paths containing spaces do not break the build.
-- [ ] Debug and release artifacts can coexist.
-- [ ] Build failure messages identify the failed command.
-- [ ] `compile_commands.json` is generated for editor tooling.
-
-## Exit criteria
-
-A contributor can clone, configure, compile, inspect the ELF and launch the debugger without manually editing any path.
+Un collaboratore può clonare, configurare, compilare, ispezionare l’ELF e avviare il debugger senza modificare percorsi a mano.
 
 ---
 
-# M1 — Controlled 64-bit boot
+# M1 — Boot controllato a 64 bit
 
-## Goal
+## Obiettivo
 
-Enter the kernel in a known 64-bit execution environment, validate boot information and halt safely.
+Entrare nel kernel in un ambiente noto, validare le informazioni di boot e arrestarsi in sicurezza.
 
-## Architecture-neutral contract
+## Contratto generico
 
-Define a small boot-information structure owned by the kernel rather than leaking bootloader-specific structures throughout the codebase.
-
-Suggested interface:
+Il kernel possiede una struttura `boot_info` normalizzata. Le strutture Limine restano confinate nell’adapter.
 
 ```c
 struct boot_info;
-
 [[nodiscard]] bool boot_capture_info(struct boot_info *out);
 [[noreturn]] void platform_halt(void);
 ```
 
-The generic kernel should receive normalized information such as:
+Le informazioni includono regioni di memoria, posizione del kernel, firmware, framebuffer opzionale, moduli, command line e descrizione hardware.
 
-- memory regions;
-- kernel image location;
-- firmware type;
-- framebuffer description, when available;
-- modules;
-- command line;
-- hardware-description roots.
+## Implementazione x86_64
 
-## x86_64 implementation
+Limine, UEFI, ELF64, entry virtuale high-half se prevista e seriale come primo backend.
 
-- Limine protocol;
-- UEFI boot;
-- ELF64 kernel;
-- higher-half virtual entry if selected by the linker design;
-- serial port as the first diagnostic backend.
+## Checklist
 
-## Deliverables
+- [ ] linker script documentato;
+- [ ] simbolo di entry esplicito;
+- [ ] richieste Limine validate prima dell’uso;
+- [ ] conversione verso strutture del kernel;
+- [ ] driver seriale early;
+- [ ] halt controllato;
+- [ ] immagine incrementale;
+- [ ] strumenti per ispezionare header e sezioni ELF;
+- [ ] conferma modalità 64 bit e allineamento dello stack;
+- [ ] assenza di crash con informazioni opzionali mancanti;
+- [ ] errore deterministico se manca un’informazione obbligatoria.
 
-- [ ] Linker script with documented sections.
-- [ ] Explicit kernel entry symbol.
-- [ ] Limine request declarations.
-- [ ] Response validation before dereference.
-- [ ] Conversion from Limine data to kernel-owned boot structures.
-- [ ] Early serial driver.
-- [ ] Controlled halt loop.
-- [ ] Boot image generation as an incremental target.
-- [ ] Script to inspect kernel ELF headers and sections.
-
-## Verification checklist
-
-- [ ] Kernel entry is reached under UEFI.
-- [ ] The CPU is confirmed to be in 64-bit mode.
-- [ ] Stack alignment matches the selected ABI contract.
-- [ ] Bootloader responses are checked for null and count bounds.
-- [ ] Missing optional information does not crash the kernel.
-- [ ] Missing mandatory information produces a deterministic halt message.
-- [ ] Kernel virtual and physical addresses are logged.
-- [ ] Memory-map entry count is logged.
-- [ ] QEMU exits or halts deterministically during automated tests.
-
-## Observable result
+Risultato:
 
 ```text
-[boot] entered 64-bit kernel
-[boot] boot information normalized
-[boot] serial console ready
-[ok] controlled boot complete
+[boot] ingresso nel kernel a 64 bit
+[boot] informazioni normalizzate
+[boot] console seriale pronta
+[ok] boot controllato completato
 ```
-
-## Exit criteria
-
-The kernel starts repeatedly with deterministic output and no direct bootloader dependency outside the boot adapter.
 
 ---
 
-# M2 — Diagnostics, execution context and exceptions
+# M2 — Diagnostica, contesto di esecuzione ed eccezioni
 
-## Goal
+## Obiettivo
 
-Build the diagnostic foundation required to debug every later subsystem.
+Costruire gli strumenti necessari a diagnosticare tutti i sottosistemi successivi.
 
-## Architecture-neutral contract
+## Contratto generico
 
-Generic facilities:
-
-- logging levels and sinks;
-- panic reporting;
-- architecture-neutral register/context presentation;
-- exception classification;
-- stack tracing interface;
-- source-location macros.
-
-Suggested boundaries:
+Logging, panic, classificazione delle eccezioni, vista diagnostica del contesto CPU, stack trace e informazioni sulla sorgente.
 
 ```c
 struct cpu_context;
 struct exception_info;
-
 void exception_dispatch(const struct exception_info *info,
                         const struct cpu_context *context);
 [[noreturn]] void panic(const char *message);
 ```
 
-## x86_64 implementation
+## Backend x86_64
 
-- GDT;
-- TSS;
-- IDT;
-- 256 interrupt stubs;
-- exception error-code normalization;
-- CR2 capture for page faults;
-- frame-pointer stack trace;
-- double-fault emergency stack through IST.
+GDT, TSS, IDT, stub dei 256 vettori, normalizzazione dell’error code, CR2, frame-pointer stack trace e stack IST per double fault.
 
-## Deliverables
+## Checklist
 
-- [ ] Structured log API.
-- [ ] Serial log sink.
-- [ ] Panic path without heap allocation.
-- [ ] `[[noreturn]]` annotations.
-- [ ] GDT setup.
-- [ ] TSS setup.
-- [ ] Dedicated stack for critical exceptions.
-- [ ] IDT construction.
-- [ ] Assembly entry stubs.
-- [ ] Uniform saved-context structure.
-- [ ] Static assertions for assembly/C layout agreement.
-- [ ] Human-readable exception names.
-- [ ] Page-fault bit decoding.
-- [ ] Register dump.
-- [ ] Basic stack trace.
+- [ ] logger strutturato e sink seriale;
+- [ ] panic privo di allocazioni;
+- [ ] GDT, TSS e IDT;
+- [ ] stack dedicato alle eccezioni critiche;
+- [ ] contesto salvato uniforme;
+- [ ] `static_assert` tra layout C e assembly;
+- [ ] nomi leggibili delle eccezioni;
+- [ ] decodifica page fault;
+- [ ] dump registri e stack trace;
+- [ ] test divisione per zero, invalid opcode, breakpoint e page fault;
+- [ ] gestione deterministica di fault annidati.
 
-## Verification checklist
+## Criterio d’uscita
 
-- [ ] Divide-by-zero reaches the expected handler.
-- [ ] Invalid opcode reaches the expected handler.
-- [ ] Breakpoint exception can return safely.
-- [ ] Page fault reports the faulting virtual address.
-- [ ] Page-fault access type is decoded.
-- [ ] Stack trace includes at least two known functions.
-- [ ] Panic remains functional before memory allocation exists.
-- [ ] Nested fatal faults terminate deterministically.
-- [ ] C structure offsets match assembly constants.
-- [ ] Exception tests run automatically in QEMU.
-
-## Exit criteria
-
-Every fatal CPU exception produces enough information to identify the instruction, saved context and likely cause.
+Ogni eccezione fatale produce istruzione, contesto salvato e informazioni sufficienti a individuare la causa probabile.
 
 ---
 
-# M3 — Physical memory ownership
+# M3 — Proprietà della memoria fisica
 
-## Goal
+## Obiettivo
 
-Represent physical memory safely and allocate page frames without hidden bootloader assumptions.
+Rappresentare la memoria fisica e allocare frame senza dipendenze nascoste dal bootloader.
 
-## Architecture-neutral contract
-
-A physical-memory manager deals in page-frame identifiers or strongly named physical addresses. It must not expose x86 page-table formats.
-
-Suggested interface:
+## Contratto generico
 
 ```c
 typedef struct { uintptr_t value; } paddr_t;
@@ -261,60 +172,36 @@ enum pmm_status {
     PMM_NOT_OWNED,
     PMM_DOUBLE_FREE,
 };
-
-[[nodiscard]] enum pmm_status pmm_alloc_page(paddr_t *out);
-[[nodiscard]] enum pmm_status pmm_free_page(paddr_t page);
 ```
 
-## x86_64 implementation
+Il PMM non espone il formato delle page table x86.
 
-- 4 KiB base pages initially;
-- bitmap-backed page-frame allocator;
-- Limine memory-map adapter;
-- explicit reservations for kernel, boot structures, modules and framebuffer.
+## Implementazione iniziale
 
-## Deliverables
+Pagine base da 4 KiB, allocator bitmap, adapter della memory map Limine, riserve esplicite per kernel, boot, moduli e framebuffer.
 
-- [ ] Normalized memory-region model.
-- [ ] Region sorting and overlap validation.
-- [ ] Page-alignment helpers.
-- [ ] Page-frame database or bitmap.
-- [ ] Reservation API.
-- [ ] Single-page allocation.
-- [ ] Multiple-page allocation with explicit semantics.
-- [ ] Free operation.
-- [ ] Statistics.
-- [ ] Integrity checker.
-- [ ] Debug ownership metadata where affordable.
+## Checklist
 
-## Verification checklist
-
-- [ ] All non-usable regions remain unavailable.
-- [ ] Kernel image pages are reserved.
-- [ ] Boot structures remain reserved until explicitly released.
-- [ ] Every returned page is aligned.
-- [ ] No page is returned twice while allocated.
-- [ ] Allocation exhaustion returns an error rather than panicking unexpectedly.
-- [ ] Double free is detected in debug mode.
-- [ ] Invalid and unaligned frees are rejected.
-- [ ] Allocate-all/free-all restores the initial free-page count.
-- [ ] Region normalization is host-tested with malformed maps.
-
-## Exit criteria
-
-The kernel can prove which physical pages it owns and can detect common ownership violations.
+- [ ] modello normalizzato delle regioni;
+- [ ] ordinamento e controllo sovrapposizioni;
+- [ ] helper di allineamento;
+- [ ] bitmap dei frame;
+- [ ] API di riserva, allocazione e free;
+- [ ] statistiche e integrity checker;
+- [ ] nessuna regione non usabile viene allocata;
+- [ ] ogni pagina restituita è allineata e unica;
+- [ ] esaurimento restituisce errore;
+- [ ] double-free e free non valido rilevati in debug;
+- [ ] allocate-all/free-all ripristina il conteggio;
+- [ ] normalizzazione testata sull’host con mappe malformate.
 
 ---
 
-# M4 — Virtual address spaces
+# M4 — Spazi di indirizzamento virtuale
 
-## Goal
+## Obiettivo
 
-Create an architecture-independent virtual-memory API backed initially by x86_64 page tables.
-
-## Architecture-neutral contract
-
-Generic code works with address-space objects and portable mapping permissions.
+Creare un’API di memoria virtuale generica sostenuta inizialmente dalle page table x86_64.
 
 ```c
 typedef struct address_space address_space_t;
@@ -328,463 +215,222 @@ enum vm_flags {
 };
 ```
 
-Architecture code translates generic permissions into hardware entries.
+## Backend x86_64
 
-## x86_64 implementation
+Paging a quattro livelli, indirizzi canonici, direct map, kernel high-half, NX, CR3 e invalidazione TLB.
 
-- four-level paging initially;
-- canonical-address validation;
-- page-table allocation through PMM;
-- direct physical map;
-- higher-half kernel;
-- NX support;
-- CR3 activation;
-- `invlpg` and address-space TLB rules.
+## Checklist
 
-## Deliverables
-
-- [ ] Address-space object.
-- [ ] Page-table walker.
-- [ ] Map operation.
-- [ ] Unmap operation.
-- [ ] Resolve/query operation.
-- [ ] Permission conversion layer.
-- [ ] Direct-map helpers.
-- [ ] Kernel mapping inheritance policy.
-- [ ] User/kernel address split policy.
-- [ ] TLB invalidation abstraction.
-- [ ] Page-table destruction.
-- [ ] Debug dump and integrity checker.
-
-## Verification checklist
-
-- [ ] Mapping then resolving returns the expected physical address.
-- [ ] Unmapping removes access.
-- [ ] Duplicate mapping follows a documented policy.
-- [ ] Non-canonical addresses are rejected.
-- [ ] User mappings cannot overwrite protected kernel mappings.
-- [ ] Read-only pages fault on writes.
-- [ ] NX pages fault on instruction fetch when supported.
-- [ ] Address-space destruction releases page-table frames.
-- [ ] Failed partial mappings roll back correctly.
-- [ ] Tests cover page-table boundaries.
-
-## Exit criteria
-
-The generic kernel can create, modify, activate and destroy an address space without manipulating x86_64 page-table entries directly.
+- [ ] oggetto address space;
+- [ ] page-table walker;
+- [ ] map, unmap e query;
+- [ ] traduzione dei permessi;
+- [ ] helper direct map;
+- [ ] separazione kernel/utente;
+- [ ] distruzione delle page table;
+- [ ] dump e integrity checker;
+- [ ] map/resolve e unmap verificati;
+- [ ] indirizzi non canonici rifiutati;
+- [ ] pagine read-only e NX realmente protette;
+- [ ] rollback dei mapping parziali;
+- [ ] test ai confini di ogni livello.
 
 ---
 
-# M5 — Kernel dynamic memory
+# M5 — Memoria dinamica del kernel
 
-## Goal
+## Obiettivo
 
-Provide reliable dynamic allocation for kernel objects without prematurely introducing complex allocators.
+Offrire allocazione dinamica affidabile senza introdurre subito allocator complessi.
 
-## Architecture-neutral contract
+## Implementazione
 
-The kernel allocation API must define:
+Bump allocator early, espansione sostenuta da pagine e free list allineata.
 
-- alignment;
-- zero-size behavior;
-- out-of-memory behavior;
-- ownership and lifetime;
-- interrupt-context restrictions;
-- debug guarantees.
+## Checklist
 
-## Initial implementation
-
-- early bump allocator;
-- page-backed heap expansion;
-- aligned free-list allocator;
-- optional allocation metadata in debug builds.
-
-## Deliverables
-
-- [ ] Early allocator with explicit retirement point.
-- [ ] `kmalloc`, `kfree` and aligned allocation.
-- [ ] Heap virtual-region manager.
-- [ ] Page acquisition from PMM/VMM.
-- [ ] Block splitting.
-- [ ] Adjacent-block coalescing.
-- [ ] Overflow-safe size calculations.
-- [ ] Poison patterns in debug builds.
-- [ ] Allocation statistics.
-- [ ] Heap integrity walk.
-
-## Verification checklist
-
-- [ ] Common alignments are respected.
-- [ ] Zero-size behavior is documented and tested.
-- [ ] Allocation failure is recoverable where required.
-- [ ] Split and merge behavior is host-tested.
-- [ ] Repeated random allocation sequences preserve integrity.
-- [ ] Double free and invalid free are diagnosed in debug builds.
-- [ ] Heap expansion maps and releases pages correctly.
-- [ ] The panic path does not depend on the heap.
-- [ ] No allocator is called from unsupported interrupt contexts.
-
-## Exit criteria
-
-Kernel subsystems can allocate objects with a documented failure model, and allocator corruption is discoverable close to its source.
+- [ ] retirement esplicito dell’allocator early;
+- [ ] `kmalloc`, `kfree` e allocazione allineata;
+- [ ] gestione della regione virtuale dell’heap;
+- [ ] splitting e coalescing;
+- [ ] calcoli delle dimensioni protetti da overflow;
+- [ ] poisoning e statistiche debug;
+- [ ] integrity walk;
+- [ ] allineamenti e zero-size documentati;
+- [ ] test randomizzati host-side;
+- [ ] double-free e invalid-free diagnosticati;
+- [ ] il panic non dipende dall’heap.
 
 ---
 
-# M6 — Interrupt delivery and time
+# M6 — Interrupt hardware e tempo
 
-## Goal
+## Obiettivo
 
-Deliver hardware events and establish a monotonic kernel time source.
+Consegnare eventi hardware e stabilire un tempo monotono del kernel.
 
-## Architecture-neutral contract
+## Contratto generico
 
-Define generic concepts:
+Sorgente interrupt, registrazione handler, acknowledgement, mask/unmask, clock monotono e clock event. Nessun registro APIC è visibile al codice generico.
 
-- interrupt vector or event identifier;
-- interrupt source;
-- handler registration;
-- acknowledgement;
-- mask/unmask;
-- monotonic clock;
-- timer deadline or periodic tick.
+## Backend x86_64
 
-Do not expose APIC register layouts to generic code.
+Scoperta ACPI, Local APIC, IOAPIC, disattivazione PIC legacy e timer calibrato.
 
-## x86_64 implementation
+## Checklist
 
-- ACPI discovery sufficient for interrupt controllers;
-- Local APIC;
-- IOAPIC;
-- legacy PIC disable;
-- LAPIC or alternative timer calibration;
-- periodic timer for the first scheduler.
-
-## Deliverables
-
-- [ ] Interrupt-controller interface.
-- [ ] Timer/clock interface.
-- [ ] ACPI table checksum and bounds validation.
-- [ ] MADT parsing.
-- [ ] Local APIC setup.
-- [ ] IOAPIC redirection setup.
-- [ ] Legacy PIC shutdown.
-- [ ] IRQ registration and dispatch.
-- [ ] Spurious interrupt handling.
-- [ ] Monotonic tick counter.
-- [ ] Timer calibration strategy.
-
-## Verification checklist
-
-- [ ] Timer interrupts arrive repeatedly.
-- [ ] Each interrupt is acknowledged exactly once.
-- [ ] Unknown interrupts are diagnosed safely.
-- [ ] Masking prevents delivery.
-- [ ] Unmasking restores delivery.
-- [ ] Interrupt handlers do not allocate unless explicitly permitted.
-- [ ] Time never moves backward.
-- [ ] Spurious interrupts do not panic the system.
-- [ ] ACPI parsing rejects invalid checksums and lengths.
-
-## Exit criteria
-
-The kernel receives deterministic timer events through an architecture-neutral dispatcher.
+- [ ] interfacce controller e timer;
+- [ ] checksum e limiti ACPI validati;
+- [ ] parsing MADT;
+- [ ] configurazione LAPIC e IOAPIC;
+- [ ] gestione interrupt spuri;
+- [ ] contatore monotono;
+- [ ] interrupt periodici deterministici;
+- [ ] acknowledgement eseguito una sola volta;
+- [ ] mask/unmask verificati;
+- [ ] handler senza allocazione non autorizzata;
+- [ ] il tempo non torna indietro.
 
 ---
 
-# M7 — Kernel threads and scheduler
+# M7 — Thread kernel e scheduler
 
-## Goal
+## Obiettivo
 
-Run multiple independent kernel execution contexts on one CPU.
+Eseguire più contesti kernel indipendenti su una CPU.
 
-## Architecture-neutral contract
+Il livello generico possiede thread, stati, ready queue, politica, blocco e risveglio. Il backend possiede la costruzione del contesto e lo switch low-level.
 
-Define:
+## Checklist
 
-- thread identity;
-- saved execution context;
-- thread states;
-- scheduling policy interface;
-- blocking and wake-up;
-- preemption boundary;
-- architecture context-switch hooks.
-
-## x86_64 implementation
-
-- saved callee-preserved registers;
-- stack switching;
-- timer-driven preemption;
-- single-core round-robin scheduler.
-
-## Deliverables
-
-- [ ] Thread object.
-- [ ] Dedicated kernel stack.
-- [ ] Initial context construction.
-- [ ] Architecture context-switch routine.
-- [ ] Ready queue.
-- [ ] Idle thread.
-- [ ] Cooperative yield.
-- [ ] Timer preemption.
-- [ ] Block and wake operations.
-- [ ] Thread exit and resource reclamation.
-- [ ] Scheduler invariants and tracing.
-
-## Verification checklist
-
-- [ ] Two threads alternate cooperatively.
-- [ ] Two threads alternate through timer preemption.
-- [ ] Register values survive context switches.
-- [ ] Each thread uses its own stack.
-- [ ] A blocked thread does not execute.
-- [ ] A woken thread becomes runnable.
-- [ ] Exiting threads are eventually reclaimed.
-- [ ] Ready-queue corruption is detected.
-- [ ] The idle thread runs only with no runnable work.
-
-## Exit criteria
-
-Multiple kernel threads run, block, resume and terminate predictably on a single x86_64 processor.
+- [ ] oggetto thread e stack dedicato;
+- [ ] contesto iniziale;
+- [ ] routine di context switch;
+- [ ] ready queue e idle thread;
+- [ ] yield cooperativo;
+- [ ] preemption da timer;
+- [ ] block/wake;
+- [ ] terminazione e reclamazione;
+- [ ] invarianti e tracing;
+- [ ] registri preservati tra switch;
+- [ ] thread bloccati non eseguiti;
+- [ ] idle eseguito solo in assenza di lavoro.
 
 ---
 
-# M8 — User execution domain
+# M8 — Dominio di esecuzione utente
 
-## Goal
+## Obiettivo
 
-Execute untrusted code in a less-privileged address space and contain its faults.
+Eseguire codice non fidato in uno spazio meno privilegiato e contenerne i fault.
 
-## Architecture-neutral contract
+## Backend x86_64
 
-Generic process concepts:
+Ring 3, TSS con stack kernel, ingresso iniziale tramite `iretq`, permessi user/supervisor.
 
-- process-owned address space;
-- user virtual-memory range;
-- user entry point and stack;
-- safe user-memory access;
-- fault ownership;
-- process termination.
+## Checklist
 
-## x86_64 implementation
-
-- Ring 3 segments;
-- TSS kernel stack selection;
-- `iretq` entry initially;
-- user-accessible page permissions;
-- supervisor/user fault distinction.
-
-## Deliverables
-
-- [ ] Process object.
-- [ ] Per-process address space.
-- [ ] User stack construction.
-- [ ] Ring 3 transition.
-- [ ] Return to kernel through a controlled mechanism.
-- [ ] User pointer range checks.
-- [ ] `copy_from_user` and `copy_to_user`.
-- [ ] Process-fault termination.
-- [ ] Kernel-fault distinction.
-
-## Verification checklist
-
-- [ ] A user function executes at reduced privilege.
-- [ ] User code cannot write kernel pages.
-- [ ] User code cannot execute privileged instructions.
-- [ ] A user page fault terminates only the offending process.
-- [ ] A kernel page fault still triggers kernel panic.
-- [ ] Invalid user pointers are rejected.
-- [ ] User stack alignment matches the selected ABI.
-- [ ] Switching processes changes address spaces safely.
-
-## Exit criteria
-
-The kernel can execute and contain a deliberately faulty user program without losing control.
+- [ ] oggetto processo e address space dedicato;
+- [ ] stack utente;
+- [ ] transizione a Ring 3;
+- [ ] ritorno controllato al kernel;
+- [ ] controlli dei range utente;
+- [ ] `copy_from_user` e `copy_to_user`;
+- [ ] terminazione del solo processo che genera fault;
+- [ ] distinzione tra fault kernel e utente;
+- [ ] impossibilità di scrivere pagine kernel o eseguire istruzioni privilegiate;
+- [ ] allineamento ABI dello stack.
 
 ---
 
-# M9 — System-call boundary
+# M9 — Confine delle chiamate di sistema
 
-## Goal
+## Obiettivo
 
-Provide a documented and testable interface between user programs and the kernel.
+Fornire un’interfaccia documentata tra programmi utente e kernel.
 
-## Architecture-neutral contract
+## Checklist
 
-The syscall layer defines:
-
-- syscall numbering;
-- argument types and ownership;
-- return and error convention;
-- restart/interruption policy;
-- pointer validation;
-- compatibility/versioning policy.
-
-## x86_64 implementation
-
-- start with a simple, debuggable entry mechanism;
-- move to `syscall/sysret` after correctness is established;
-- explicitly document register use and clobbers.
-
-## Deliverables
-
-- [ ] Syscall ABI document.
-- [ ] Entry and return assembly.
-- [ ] Dispatcher.
-- [ ] Unknown-syscall error.
-- [ ] `write`.
-- [ ] `exit`.
-- [ ] `yield`.
-- [ ] Safe user-buffer handling.
-- [ ] Per-syscall tracing in debug builds.
-
-## Verification checklist
-
-- [ ] Valid syscalls return expected results.
-- [ ] Unknown syscall numbers return a stable error.
-- [ ] Invalid user pointers cannot crash the kernel.
-- [ ] Oversized lengths are rejected safely.
-- [ ] ABI register preservation is tested.
-- [ ] User code cannot select an arbitrary kernel return address.
-- [ ] Process exit releases or schedules reclamation of resources.
-
-## Exit criteria
-
-A user program can print, yield and exit entirely through the documented syscall ABI.
+- [ ] documento ABI;
+- [ ] assembly di ingresso e ritorno;
+- [ ] dispatcher;
+- [ ] errore stabile per syscall sconosciute;
+- [ ] `write`, `exit`, `yield`;
+- [ ] validazione dei buffer utente;
+- [ ] tracing debug;
+- [ ] test di puntatori errati e lunghezze estreme;
+- [ ] registri preservati secondo ABI;
+- [ ] indirizzo di ritorno non controllabile arbitrariamente dall’utente.
 
 ---
 
-# M10 — Initramfs and ELF64 program loading
+# M10 — Initramfs e caricamento ELF64
 
-## Goal
+## Obiettivo
 
-Load user programs from a boot-provided archive without depending on storage drivers.
+Caricare programmi utente da un archivio fornito al boot senza dipendere da driver storage.
 
-## Architecture-neutral contract
+## Contratti separati
 
-Separate:
+Scoperta dei moduli, accesso all’archivio, parsing dell’eseguibile e costruzione dell’immagine del processo.
 
-- boot module discovery;
-- archive access;
-- executable-format parsing;
-- process image construction.
+## Implementazione iniziale
 
-The generic loader consumes a byte source and produces validated load segments.
+Adapter Limine, TAR/USTAR, ELF64 little-endian x86_64 e binari statici.
 
-## x86_64 implementation
+## Checklist
 
-- Limine module adapter;
-- TAR or USTAR initramfs;
-- ELF64 little-endian executables for x86_64;
-- initially static, non-dynamic executables.
+- [ ] normalizzazione dei moduli;
+- [ ] lettore archivio bounds-checked;
+- [ ] lookup dei percorsi;
+- [ ] validazione header e program header ELF;
+- [ ] mapping dei segmenti con permessi corretti;
+- [ ] azzeramento BSS;
+- [ ] validazione entry point;
+- [ ] stack utente iniziale;
+- [ ] rifiuto di architettura errata, file troncati, overflow e segmenti invalidi.
 
-## Deliverables
-
-- [ ] Boot-module normalization.
-- [ ] Bounds-checked archive reader.
-- [ ] Path lookup inside initramfs.
-- [ ] ELF header validation.
-- [ ] Program-header validation.
-- [ ] Segment mapping with permissions.
-- [ ] BSS zeroing.
-- [ ] Entry-point validation.
-- [ ] Initial user stack.
-- [ ] First freestanding user program.
-
-## Verification checklist
-
-- [ ] Valid executable starts.
-- [ ] Wrong architecture is rejected.
-- [ ] Truncated ELF files are rejected.
-- [ ] Overflowing offsets and sizes are rejected.
-- [ ] Overlapping invalid segments are rejected.
-- [ ] Segment permissions match ELF flags.
-- [ ] BSS is zero-filled.
-- [ ] Entry point lies within a valid executable mapping.
-- [ ] Malformed archive entries cannot read out of bounds.
-
-## Observable result
+Risultato:
 
 ```text
-hello from userspace
+ciao dallo spazio utente
 ```
 
-## Exit criteria
+---
 
-The kernel creates a process from an initramfs ELF64 file and the program communicates through syscalls.
+# M11 — Virtual File System minimale
+
+## Obiettivo
+
+Fornire namespace e interfaccia file indipendenti dal filesystem sottostante.
+
+## Implementazione iniziale
+
+Filesystem initramfs read-only, `/dev/console` e tabella descriptor per processo.
+
+## Checklist
+
+- [ ] modello VFS;
+- [ ] mount table;
+- [ ] parser dei percorsi assoluti;
+- [ ] attraversamento dei componenti;
+- [ ] oggetto file e offset;
+- [ ] allocazione descriptor;
+- [ ] interfacce `open`, `read`, `write`, `close`;
+- [ ] mount root dell’initramfs;
+- [ ] dispositivo console;
+- [ ] gestione documentata di `.`, `..` e separatori ripetuti;
+- [ ] limiti dei descriptor;
+- [ ] offset indipendenti per handle distinti.
+
+## Criterio d’uscita
+
+Un programma utente apre un file nell’initramfs e ne scrive il contenuto su `/dev/console`.
 
 ---
 
-# M11 — Minimal Virtual File System
+# Milestone rimandate
 
-## Goal
+Dopo M0–M11: sincronizzazione avanzata, SMP e dati per-CPU, PCI, storage, FAT/ext2, pipe, rete, grafica, USB, dynamic linking, compatibilità POSIX e backend ARM64/RISC-V.
 
-Provide a generic namespace and file interface independent of the underlying filesystem.
-
-## Architecture-neutral contract
-
-Core concepts:
-
-- vnode or inode-like object;
-- mount;
-- filesystem operations;
-- file handle;
-- descriptor table;
-- path resolution;
-- device nodes.
-
-## Initial implementation
-
-- read-only initramfs filesystem;
-- `/dev/console` device;
-- per-process file-descriptor table.
-
-## Deliverables
-
-- [ ] VFS object model.
-- [ ] Mount table.
-- [ ] Absolute path parser.
-- [ ] Path-component traversal.
-- [ ] File object and offset.
-- [ ] Descriptor allocation.
-- [ ] `open`, `read`, `write`, `close` kernel interfaces.
-- [ ] Initramfs root mount.
-- [ ] Console device node.
-- [ ] Corresponding syscalls.
-
-## Verification checklist
-
-- [ ] Root path resolves.
-- [ ] Existing initramfs files can be read.
-- [ ] Missing paths return a stable error.
-- [ ] Repeated separators and `.` follow documented behavior.
-- [ ] `..` cannot escape the root.
-- [ ] Descriptor limits are enforced.
-- [ ] Closing an invalid descriptor is safe.
-- [ ] Independent file handles maintain independent offsets.
-- [ ] Console writes reach the selected log/terminal backend.
-
-## Exit criteria
-
-A user program can open and read a file from the initramfs and write its contents to `/dev/console`.
-
----
-
-# Deferred milestones
-
-The following are intentionally postponed until M0–M11 are stable:
-
-- synchronization primitives beyond initial scheduler needs;
-- SMP and per-CPU data;
-- ACPI expansion;
-- PCI discovery;
-- storage drivers;
-- FAT or ext2;
-- pipes and IPC;
-- networking;
-- graphical output;
-- USB;
-- dynamic linking;
-- POSIX compatibility;
-- ARM64 or RISC-V backends.
-
-When a second architecture is introduced, the abstraction boundaries created above must be validated by implementing the smallest possible second backend rather than redesigning the entire kernel in advance.
+Una seconda architettura dovrà validare i confini esistenti con il backend minimo possibile, non provocare una riprogettazione speculativa dell’intero kernel.

--- a/docs/new-project/MILESTONES_DETAILED.md
+++ b/docs/new-project/MILESTONES_DETAILED.md
@@ -1,0 +1,790 @@
+# Detailed Milestones and Completion Checklists
+
+This document turns the high-level roadmap into executable project milestones.
+
+The initial implementation target is **64-bit x86 (`x86_64`)**, but kernel-facing contracts should avoid unnecessary architecture assumptions. Platform-specific details belong behind explicit architecture interfaces.
+
+## Milestone rules
+
+Every milestone must satisfy all of these rules before it is considered complete:
+
+- [ ] The result is observable in QEMU or through a host-side test.
+- [ ] Failure paths are deliberately exercised.
+- [ ] Public interfaces are documented.
+- [ ] Architecture-specific code is isolated under `kernel/arch/x86_64/`.
+- [ ] Generic kernel code does not directly access x86 registers, ports or descriptor tables.
+- [ ] Debug and release builds compile without warnings.
+- [ ] The CI pipeline executes the relevant tests.
+- [ ] The documentation and architecture diagrams are updated.
+- [ ] The milestone ends with a reproducible Git tag.
+- [ ] The corresponding YouTube episode notes include start and completion references.
+
+---
+
+# M0 — Reproducible 64-bit development workspace
+
+## Goal
+
+Create a fast, understandable and reproducible workspace for a freestanding 64-bit kernel.
+
+## Architecture-neutral contract
+
+The build system must model the target platform through configuration rather than hard-coding x86 commands across scripts.
+
+Expected concepts:
+
+- target architecture;
+- target machine word size;
+- compiler and linker;
+- platform sources;
+- emulator backend;
+- firmware and boot protocol;
+- debug transport.
+
+## x86_64 implementation
+
+- Clang with an x86_64 freestanding target;
+- LLD linker;
+- Meson configuration;
+- Ninja incremental build;
+- QEMU `q35` machine;
+- UEFI firmware;
+- GDB remote debugging;
+- serial terminal output.
+
+## Deliverables
+
+- [ ] Root `meson.build`.
+- [ ] `meson_options.txt` for debug features and kernel tests.
+- [ ] `config/x86_64.ini` cross file.
+- [ ] Explicit compiler and linker flags.
+- [ ] Debug and release build profiles.
+- [ ] Dependency checking command.
+- [ ] `tools/dev` command wrapper.
+- [ ] QEMU launcher.
+- [ ] GDB launcher and initial command file.
+- [ ] CI workflow for configuration and compilation.
+- [ ] Pinned tool versions or documented supported ranges.
+- [ ] No mandatory Docker dependency for the local edit-build-run cycle.
+- [ ] Optional container image for reproducibility and CI.
+
+## Verification checklist
+
+- [ ] A clean clone configures with one documented command.
+- [ ] The source tree remains unchanged after a build.
+- [ ] Touching one C file recompiles only one translation unit and relinks.
+- [ ] Touching one header recompiles only dependent translation units.
+- [ ] A no-op rebuild performs no compilation.
+- [ ] Parallel builds succeed.
+- [ ] Paths containing spaces do not break the build.
+- [ ] Debug and release artifacts can coexist.
+- [ ] Build failure messages identify the failed command.
+- [ ] `compile_commands.json` is generated for editor tooling.
+
+## Exit criteria
+
+A contributor can clone, configure, compile, inspect the ELF and launch the debugger without manually editing any path.
+
+---
+
+# M1 — Controlled 64-bit boot
+
+## Goal
+
+Enter the kernel in a known 64-bit execution environment, validate boot information and halt safely.
+
+## Architecture-neutral contract
+
+Define a small boot-information structure owned by the kernel rather than leaking bootloader-specific structures throughout the codebase.
+
+Suggested interface:
+
+```c
+struct boot_info;
+
+[[nodiscard]] bool boot_capture_info(struct boot_info *out);
+[[noreturn]] void platform_halt(void);
+```
+
+The generic kernel should receive normalized information such as:
+
+- memory regions;
+- kernel image location;
+- firmware type;
+- framebuffer description, when available;
+- modules;
+- command line;
+- hardware-description roots.
+
+## x86_64 implementation
+
+- Limine protocol;
+- UEFI boot;
+- ELF64 kernel;
+- higher-half virtual entry if selected by the linker design;
+- serial port as the first diagnostic backend.
+
+## Deliverables
+
+- [ ] Linker script with documented sections.
+- [ ] Explicit kernel entry symbol.
+- [ ] Limine request declarations.
+- [ ] Response validation before dereference.
+- [ ] Conversion from Limine data to kernel-owned boot structures.
+- [ ] Early serial driver.
+- [ ] Controlled halt loop.
+- [ ] Boot image generation as an incremental target.
+- [ ] Script to inspect kernel ELF headers and sections.
+
+## Verification checklist
+
+- [ ] Kernel entry is reached under UEFI.
+- [ ] The CPU is confirmed to be in 64-bit mode.
+- [ ] Stack alignment matches the selected ABI contract.
+- [ ] Bootloader responses are checked for null and count bounds.
+- [ ] Missing optional information does not crash the kernel.
+- [ ] Missing mandatory information produces a deterministic halt message.
+- [ ] Kernel virtual and physical addresses are logged.
+- [ ] Memory-map entry count is logged.
+- [ ] QEMU exits or halts deterministically during automated tests.
+
+## Observable result
+
+```text
+[boot] entered 64-bit kernel
+[boot] boot information normalized
+[boot] serial console ready
+[ok] controlled boot complete
+```
+
+## Exit criteria
+
+The kernel starts repeatedly with deterministic output and no direct bootloader dependency outside the boot adapter.
+
+---
+
+# M2 — Diagnostics, execution context and exceptions
+
+## Goal
+
+Build the diagnostic foundation required to debug every later subsystem.
+
+## Architecture-neutral contract
+
+Generic facilities:
+
+- logging levels and sinks;
+- panic reporting;
+- architecture-neutral register/context presentation;
+- exception classification;
+- stack tracing interface;
+- source-location macros.
+
+Suggested boundaries:
+
+```c
+struct cpu_context;
+struct exception_info;
+
+void exception_dispatch(const struct exception_info *info,
+                        const struct cpu_context *context);
+[[noreturn]] void panic(const char *message);
+```
+
+## x86_64 implementation
+
+- GDT;
+- TSS;
+- IDT;
+- 256 interrupt stubs;
+- exception error-code normalization;
+- CR2 capture for page faults;
+- frame-pointer stack trace;
+- double-fault emergency stack through IST.
+
+## Deliverables
+
+- [ ] Structured log API.
+- [ ] Serial log sink.
+- [ ] Panic path without heap allocation.
+- [ ] `[[noreturn]]` annotations.
+- [ ] GDT setup.
+- [ ] TSS setup.
+- [ ] Dedicated stack for critical exceptions.
+- [ ] IDT construction.
+- [ ] Assembly entry stubs.
+- [ ] Uniform saved-context structure.
+- [ ] Static assertions for assembly/C layout agreement.
+- [ ] Human-readable exception names.
+- [ ] Page-fault bit decoding.
+- [ ] Register dump.
+- [ ] Basic stack trace.
+
+## Verification checklist
+
+- [ ] Divide-by-zero reaches the expected handler.
+- [ ] Invalid opcode reaches the expected handler.
+- [ ] Breakpoint exception can return safely.
+- [ ] Page fault reports the faulting virtual address.
+- [ ] Page-fault access type is decoded.
+- [ ] Stack trace includes at least two known functions.
+- [ ] Panic remains functional before memory allocation exists.
+- [ ] Nested fatal faults terminate deterministically.
+- [ ] C structure offsets match assembly constants.
+- [ ] Exception tests run automatically in QEMU.
+
+## Exit criteria
+
+Every fatal CPU exception produces enough information to identify the instruction, saved context and likely cause.
+
+---
+
+# M3 — Physical memory ownership
+
+## Goal
+
+Represent physical memory safely and allocate page frames without hidden bootloader assumptions.
+
+## Architecture-neutral contract
+
+A physical-memory manager deals in page-frame identifiers or strongly named physical addresses. It must not expose x86 page-table formats.
+
+Suggested interface:
+
+```c
+typedef struct { uintptr_t value; } paddr_t;
+
+enum pmm_status {
+    PMM_OK,
+    PMM_OUT_OF_MEMORY,
+    PMM_INVALID_ARGUMENT,
+    PMM_NOT_OWNED,
+    PMM_DOUBLE_FREE,
+};
+
+[[nodiscard]] enum pmm_status pmm_alloc_page(paddr_t *out);
+[[nodiscard]] enum pmm_status pmm_free_page(paddr_t page);
+```
+
+## x86_64 implementation
+
+- 4 KiB base pages initially;
+- bitmap-backed page-frame allocator;
+- Limine memory-map adapter;
+- explicit reservations for kernel, boot structures, modules and framebuffer.
+
+## Deliverables
+
+- [ ] Normalized memory-region model.
+- [ ] Region sorting and overlap validation.
+- [ ] Page-alignment helpers.
+- [ ] Page-frame database or bitmap.
+- [ ] Reservation API.
+- [ ] Single-page allocation.
+- [ ] Multiple-page allocation with explicit semantics.
+- [ ] Free operation.
+- [ ] Statistics.
+- [ ] Integrity checker.
+- [ ] Debug ownership metadata where affordable.
+
+## Verification checklist
+
+- [ ] All non-usable regions remain unavailable.
+- [ ] Kernel image pages are reserved.
+- [ ] Boot structures remain reserved until explicitly released.
+- [ ] Every returned page is aligned.
+- [ ] No page is returned twice while allocated.
+- [ ] Allocation exhaustion returns an error rather than panicking unexpectedly.
+- [ ] Double free is detected in debug mode.
+- [ ] Invalid and unaligned frees are rejected.
+- [ ] Allocate-all/free-all restores the initial free-page count.
+- [ ] Region normalization is host-tested with malformed maps.
+
+## Exit criteria
+
+The kernel can prove which physical pages it owns and can detect common ownership violations.
+
+---
+
+# M4 — Virtual address spaces
+
+## Goal
+
+Create an architecture-independent virtual-memory API backed initially by x86_64 page tables.
+
+## Architecture-neutral contract
+
+Generic code works with address-space objects and portable mapping permissions.
+
+```c
+typedef struct address_space address_space_t;
+
+enum vm_flags {
+    VM_READ    = 1u << 0,
+    VM_WRITE   = 1u << 1,
+    VM_EXECUTE = 1u << 2,
+    VM_USER    = 1u << 3,
+    VM_GLOBAL  = 1u << 4,
+};
+```
+
+Architecture code translates generic permissions into hardware entries.
+
+## x86_64 implementation
+
+- four-level paging initially;
+- canonical-address validation;
+- page-table allocation through PMM;
+- direct physical map;
+- higher-half kernel;
+- NX support;
+- CR3 activation;
+- `invlpg` and address-space TLB rules.
+
+## Deliverables
+
+- [ ] Address-space object.
+- [ ] Page-table walker.
+- [ ] Map operation.
+- [ ] Unmap operation.
+- [ ] Resolve/query operation.
+- [ ] Permission conversion layer.
+- [ ] Direct-map helpers.
+- [ ] Kernel mapping inheritance policy.
+- [ ] User/kernel address split policy.
+- [ ] TLB invalidation abstraction.
+- [ ] Page-table destruction.
+- [ ] Debug dump and integrity checker.
+
+## Verification checklist
+
+- [ ] Mapping then resolving returns the expected physical address.
+- [ ] Unmapping removes access.
+- [ ] Duplicate mapping follows a documented policy.
+- [ ] Non-canonical addresses are rejected.
+- [ ] User mappings cannot overwrite protected kernel mappings.
+- [ ] Read-only pages fault on writes.
+- [ ] NX pages fault on instruction fetch when supported.
+- [ ] Address-space destruction releases page-table frames.
+- [ ] Failed partial mappings roll back correctly.
+- [ ] Tests cover page-table boundaries.
+
+## Exit criteria
+
+The generic kernel can create, modify, activate and destroy an address space without manipulating x86_64 page-table entries directly.
+
+---
+
+# M5 — Kernel dynamic memory
+
+## Goal
+
+Provide reliable dynamic allocation for kernel objects without prematurely introducing complex allocators.
+
+## Architecture-neutral contract
+
+The kernel allocation API must define:
+
+- alignment;
+- zero-size behavior;
+- out-of-memory behavior;
+- ownership and lifetime;
+- interrupt-context restrictions;
+- debug guarantees.
+
+## Initial implementation
+
+- early bump allocator;
+- page-backed heap expansion;
+- aligned free-list allocator;
+- optional allocation metadata in debug builds.
+
+## Deliverables
+
+- [ ] Early allocator with explicit retirement point.
+- [ ] `kmalloc`, `kfree` and aligned allocation.
+- [ ] Heap virtual-region manager.
+- [ ] Page acquisition from PMM/VMM.
+- [ ] Block splitting.
+- [ ] Adjacent-block coalescing.
+- [ ] Overflow-safe size calculations.
+- [ ] Poison patterns in debug builds.
+- [ ] Allocation statistics.
+- [ ] Heap integrity walk.
+
+## Verification checklist
+
+- [ ] Common alignments are respected.
+- [ ] Zero-size behavior is documented and tested.
+- [ ] Allocation failure is recoverable where required.
+- [ ] Split and merge behavior is host-tested.
+- [ ] Repeated random allocation sequences preserve integrity.
+- [ ] Double free and invalid free are diagnosed in debug builds.
+- [ ] Heap expansion maps and releases pages correctly.
+- [ ] The panic path does not depend on the heap.
+- [ ] No allocator is called from unsupported interrupt contexts.
+
+## Exit criteria
+
+Kernel subsystems can allocate objects with a documented failure model, and allocator corruption is discoverable close to its source.
+
+---
+
+# M6 — Interrupt delivery and time
+
+## Goal
+
+Deliver hardware events and establish a monotonic kernel time source.
+
+## Architecture-neutral contract
+
+Define generic concepts:
+
+- interrupt vector or event identifier;
+- interrupt source;
+- handler registration;
+- acknowledgement;
+- mask/unmask;
+- monotonic clock;
+- timer deadline or periodic tick.
+
+Do not expose APIC register layouts to generic code.
+
+## x86_64 implementation
+
+- ACPI discovery sufficient for interrupt controllers;
+- Local APIC;
+- IOAPIC;
+- legacy PIC disable;
+- LAPIC or alternative timer calibration;
+- periodic timer for the first scheduler.
+
+## Deliverables
+
+- [ ] Interrupt-controller interface.
+- [ ] Timer/clock interface.
+- [ ] ACPI table checksum and bounds validation.
+- [ ] MADT parsing.
+- [ ] Local APIC setup.
+- [ ] IOAPIC redirection setup.
+- [ ] Legacy PIC shutdown.
+- [ ] IRQ registration and dispatch.
+- [ ] Spurious interrupt handling.
+- [ ] Monotonic tick counter.
+- [ ] Timer calibration strategy.
+
+## Verification checklist
+
+- [ ] Timer interrupts arrive repeatedly.
+- [ ] Each interrupt is acknowledged exactly once.
+- [ ] Unknown interrupts are diagnosed safely.
+- [ ] Masking prevents delivery.
+- [ ] Unmasking restores delivery.
+- [ ] Interrupt handlers do not allocate unless explicitly permitted.
+- [ ] Time never moves backward.
+- [ ] Spurious interrupts do not panic the system.
+- [ ] ACPI parsing rejects invalid checksums and lengths.
+
+## Exit criteria
+
+The kernel receives deterministic timer events through an architecture-neutral dispatcher.
+
+---
+
+# M7 — Kernel threads and scheduler
+
+## Goal
+
+Run multiple independent kernel execution contexts on one CPU.
+
+## Architecture-neutral contract
+
+Define:
+
+- thread identity;
+- saved execution context;
+- thread states;
+- scheduling policy interface;
+- blocking and wake-up;
+- preemption boundary;
+- architecture context-switch hooks.
+
+## x86_64 implementation
+
+- saved callee-preserved registers;
+- stack switching;
+- timer-driven preemption;
+- single-core round-robin scheduler.
+
+## Deliverables
+
+- [ ] Thread object.
+- [ ] Dedicated kernel stack.
+- [ ] Initial context construction.
+- [ ] Architecture context-switch routine.
+- [ ] Ready queue.
+- [ ] Idle thread.
+- [ ] Cooperative yield.
+- [ ] Timer preemption.
+- [ ] Block and wake operations.
+- [ ] Thread exit and resource reclamation.
+- [ ] Scheduler invariants and tracing.
+
+## Verification checklist
+
+- [ ] Two threads alternate cooperatively.
+- [ ] Two threads alternate through timer preemption.
+- [ ] Register values survive context switches.
+- [ ] Each thread uses its own stack.
+- [ ] A blocked thread does not execute.
+- [ ] A woken thread becomes runnable.
+- [ ] Exiting threads are eventually reclaimed.
+- [ ] Ready-queue corruption is detected.
+- [ ] The idle thread runs only with no runnable work.
+
+## Exit criteria
+
+Multiple kernel threads run, block, resume and terminate predictably on a single x86_64 processor.
+
+---
+
+# M8 — User execution domain
+
+## Goal
+
+Execute untrusted code in a less-privileged address space and contain its faults.
+
+## Architecture-neutral contract
+
+Generic process concepts:
+
+- process-owned address space;
+- user virtual-memory range;
+- user entry point and stack;
+- safe user-memory access;
+- fault ownership;
+- process termination.
+
+## x86_64 implementation
+
+- Ring 3 segments;
+- TSS kernel stack selection;
+- `iretq` entry initially;
+- user-accessible page permissions;
+- supervisor/user fault distinction.
+
+## Deliverables
+
+- [ ] Process object.
+- [ ] Per-process address space.
+- [ ] User stack construction.
+- [ ] Ring 3 transition.
+- [ ] Return to kernel through a controlled mechanism.
+- [ ] User pointer range checks.
+- [ ] `copy_from_user` and `copy_to_user`.
+- [ ] Process-fault termination.
+- [ ] Kernel-fault distinction.
+
+## Verification checklist
+
+- [ ] A user function executes at reduced privilege.
+- [ ] User code cannot write kernel pages.
+- [ ] User code cannot execute privileged instructions.
+- [ ] A user page fault terminates only the offending process.
+- [ ] A kernel page fault still triggers kernel panic.
+- [ ] Invalid user pointers are rejected.
+- [ ] User stack alignment matches the selected ABI.
+- [ ] Switching processes changes address spaces safely.
+
+## Exit criteria
+
+The kernel can execute and contain a deliberately faulty user program without losing control.
+
+---
+
+# M9 — System-call boundary
+
+## Goal
+
+Provide a documented and testable interface between user programs and the kernel.
+
+## Architecture-neutral contract
+
+The syscall layer defines:
+
+- syscall numbering;
+- argument types and ownership;
+- return and error convention;
+- restart/interruption policy;
+- pointer validation;
+- compatibility/versioning policy.
+
+## x86_64 implementation
+
+- start with a simple, debuggable entry mechanism;
+- move to `syscall/sysret` after correctness is established;
+- explicitly document register use and clobbers.
+
+## Deliverables
+
+- [ ] Syscall ABI document.
+- [ ] Entry and return assembly.
+- [ ] Dispatcher.
+- [ ] Unknown-syscall error.
+- [ ] `write`.
+- [ ] `exit`.
+- [ ] `yield`.
+- [ ] Safe user-buffer handling.
+- [ ] Per-syscall tracing in debug builds.
+
+## Verification checklist
+
+- [ ] Valid syscalls return expected results.
+- [ ] Unknown syscall numbers return a stable error.
+- [ ] Invalid user pointers cannot crash the kernel.
+- [ ] Oversized lengths are rejected safely.
+- [ ] ABI register preservation is tested.
+- [ ] User code cannot select an arbitrary kernel return address.
+- [ ] Process exit releases or schedules reclamation of resources.
+
+## Exit criteria
+
+A user program can print, yield and exit entirely through the documented syscall ABI.
+
+---
+
+# M10 — Initramfs and ELF64 program loading
+
+## Goal
+
+Load user programs from a boot-provided archive without depending on storage drivers.
+
+## Architecture-neutral contract
+
+Separate:
+
+- boot module discovery;
+- archive access;
+- executable-format parsing;
+- process image construction.
+
+The generic loader consumes a byte source and produces validated load segments.
+
+## x86_64 implementation
+
+- Limine module adapter;
+- TAR or USTAR initramfs;
+- ELF64 little-endian executables for x86_64;
+- initially static, non-dynamic executables.
+
+## Deliverables
+
+- [ ] Boot-module normalization.
+- [ ] Bounds-checked archive reader.
+- [ ] Path lookup inside initramfs.
+- [ ] ELF header validation.
+- [ ] Program-header validation.
+- [ ] Segment mapping with permissions.
+- [ ] BSS zeroing.
+- [ ] Entry-point validation.
+- [ ] Initial user stack.
+- [ ] First freestanding user program.
+
+## Verification checklist
+
+- [ ] Valid executable starts.
+- [ ] Wrong architecture is rejected.
+- [ ] Truncated ELF files are rejected.
+- [ ] Overflowing offsets and sizes are rejected.
+- [ ] Overlapping invalid segments are rejected.
+- [ ] Segment permissions match ELF flags.
+- [ ] BSS is zero-filled.
+- [ ] Entry point lies within a valid executable mapping.
+- [ ] Malformed archive entries cannot read out of bounds.
+
+## Observable result
+
+```text
+hello from userspace
+```
+
+## Exit criteria
+
+The kernel creates a process from an initramfs ELF64 file and the program communicates through syscalls.
+
+---
+
+# M11 — Minimal Virtual File System
+
+## Goal
+
+Provide a generic namespace and file interface independent of the underlying filesystem.
+
+## Architecture-neutral contract
+
+Core concepts:
+
+- vnode or inode-like object;
+- mount;
+- filesystem operations;
+- file handle;
+- descriptor table;
+- path resolution;
+- device nodes.
+
+## Initial implementation
+
+- read-only initramfs filesystem;
+- `/dev/console` device;
+- per-process file-descriptor table.
+
+## Deliverables
+
+- [ ] VFS object model.
+- [ ] Mount table.
+- [ ] Absolute path parser.
+- [ ] Path-component traversal.
+- [ ] File object and offset.
+- [ ] Descriptor allocation.
+- [ ] `open`, `read`, `write`, `close` kernel interfaces.
+- [ ] Initramfs root mount.
+- [ ] Console device node.
+- [ ] Corresponding syscalls.
+
+## Verification checklist
+
+- [ ] Root path resolves.
+- [ ] Existing initramfs files can be read.
+- [ ] Missing paths return a stable error.
+- [ ] Repeated separators and `.` follow documented behavior.
+- [ ] `..` cannot escape the root.
+- [ ] Descriptor limits are enforced.
+- [ ] Closing an invalid descriptor is safe.
+- [ ] Independent file handles maintain independent offsets.
+- [ ] Console writes reach the selected log/terminal backend.
+
+## Exit criteria
+
+A user program can open and read a file from the initramfs and write its contents to `/dev/console`.
+
+---
+
+# Deferred milestones
+
+The following are intentionally postponed until M0–M11 are stable:
+
+- synchronization primitives beyond initial scheduler needs;
+- SMP and per-CPU data;
+- ACPI expansion;
+- PCI discovery;
+- storage drivers;
+- FAT or ext2;
+- pipes and IPC;
+- networking;
+- graphical output;
+- USB;
+- dynamic linking;
+- POSIX compatibility;
+- ARM64 or RISC-V backends.
+
+When a second architecture is introduced, the abstraction boundaries created above must be validated by implementing the smallest possible second backend rather than redesigning the entire kernel in advance.

--- a/docs/new-project/PORTABILITY_AND_ABSTRACTION.md
+++ b/docs/new-project/PORTABILITY_AND_ABSTRACTION.md
@@ -1,0 +1,298 @@
+# Portability and Abstraction Strategy
+
+The project starts on **x86_64 in 64-bit mode**, but the codebase should avoid turning x86_64 mechanisms into universal kernel concepts.
+
+The goal is not immediate multi-architecture support. The goal is to preserve clear boundaries so that a future backend can be added without rewriting the generic kernel.
+
+## Core principle
+
+> Abstract stable concepts, not hypothetical hardware.
+
+We should not invent a large universal HAL before understanding the needs of the first implementation. We should instead isolate direct hardware access, expose small contracts and revise those contracts only when concrete evidence requires it.
+
+## Source-tree boundary
+
+```text
+kernel/
+├── arch/
+│   └── x86_64/
+│       ├── boot/
+│       ├── cpu/
+│       ├── interrupts/
+│       ├── memory/
+│       ├── time/
+│       └── context/
+├── platform/
+│   ├── firmware/
+│   ├── interrupt_controller/
+│   └── timer/
+├── core/
+├── mm/
+├── sched/
+├── process/
+├── fs/
+└── lib/
+```
+
+The exact layout may evolve, but these ownership rules should remain:
+
+- `arch/x86_64` owns instructions, registers, descriptor tables and page-table formats;
+- generic memory management owns allocation and mapping policy;
+- generic scheduling owns thread states and policy;
+- architecture code owns low-level context switching;
+- boot-protocol adapters own Limine structures;
+- generic kernel code consumes normalized boot information;
+- device-independent code consumes interfaces, not APIC or COM1 registers.
+
+## What must remain architecture-specific
+
+- entry assembly;
+- CPU feature detection;
+- control-register access;
+- MSR access;
+- exception and interrupt stubs;
+- GDT, TSS and IDT construction;
+- page-table entry encoding;
+- TLB invalidation instructions;
+- context-switch assembly;
+- privilege transition assembly;
+- syscall entry assembly;
+- port IO;
+- architecture-specific barriers;
+- APIC register access.
+
+## What should be generic
+
+- log formatting and routing;
+- panic policy;
+- normalized exception reporting;
+- physical-page ownership;
+- allocation policy;
+- address-space lifecycle;
+- generic mapping permissions;
+- heap allocation;
+- scheduler policy and queues;
+- thread and process state;
+- syscall semantics;
+- ELF parsing framework;
+- VFS;
+- file descriptors;
+- initramfs archive handling;
+- tests for pure algorithms and parsers.
+
+## Address types
+
+Avoid passing unlabelled integers when the address domain matters.
+
+```c
+typedef struct {
+    uintptr_t value;
+} paddr_t;
+
+typedef struct {
+    uintptr_t value;
+} vaddr_t;
+```
+
+These wrappers prevent accidental mixing and allow architecture-specific validation at boundaries.
+
+Operations should be explicit:
+
+```c
+[[nodiscard]] bool paddr_add(paddr_t base, size_t offset, paddr_t *out);
+[[nodiscard]] bool vaddr_add(vaddr_t base, size_t offset, vaddr_t *out);
+```
+
+## CPU context
+
+Do not force one universal register structure on every subsystem.
+
+Use two layers:
+
+1. an architecture-owned raw context containing exact saved registers;
+2. a generic diagnostic view containing common fields and accessors.
+
+```c
+struct arch_cpu_context;
+
+struct execution_view {
+    vaddr_t instruction_pointer;
+    vaddr_t stack_pointer;
+    uintptr_t flags;
+    bool from_user;
+};
+```
+
+The architecture backend converts or exposes accessors without discarding raw information.
+
+## Exceptions
+
+Generic code should reason about categories:
+
+```c
+enum exception_class {
+    EXCEPTION_ARITHMETIC,
+    EXCEPTION_INVALID_INSTRUCTION,
+    EXCEPTION_MEMORY_ACCESS,
+    EXCEPTION_BREAKPOINT,
+    EXCEPTION_HARDWARE_FAILURE,
+    EXCEPTION_UNKNOWN,
+};
+```
+
+The x86_64 backend retains the vector number and architecture-specific error code.
+
+## Virtual memory
+
+Generic VM permissions must not match x86_64 page-table bits by accident.
+
+```c
+enum vm_permission {
+    VM_PERMISSION_READ    = 1u << 0,
+    VM_PERMISSION_WRITE   = 1u << 1,
+    VM_PERMISSION_EXECUTE = 1u << 2,
+    VM_PERMISSION_USER    = 1u << 3,
+    VM_PERMISSION_GLOBAL  = 1u << 4,
+};
+```
+
+The x86_64 backend translates these into present, writable, user, global and NX semantics.
+
+Page size should be obtained through the architecture contract or build-time target description rather than repeated as a magic constant.
+
+## Interrupts
+
+Generic interrupt dispatch should not assume that every platform uses numbered IDT vectors.
+
+A generic interrupt source can contain an opaque platform identifier:
+
+```c
+struct interrupt_source {
+    uintptr_t platform_id;
+};
+```
+
+Registration, masking and acknowledgement are operations supplied by the controller backend.
+
+The first backend may map this directly to x86_64 vectors and IOAPIC entries.
+
+## Time
+
+Separate:
+
+- **clock source**: reads a continuously advancing value;
+- **clock event device**: asks hardware to interrupt at or after a deadline;
+- **kernel timekeeping**: converts and accumulates time;
+- **scheduler tick policy**: decides how the scheduler uses time.
+
+Do not let the scheduler read LAPIC or TSC registers directly.
+
+## Scheduler
+
+The generic scheduler owns:
+
+- thread states;
+- run queues;
+- policy;
+- block/wake transitions;
+- lifetime rules.
+
+The architecture backend owns:
+
+- initial register context;
+- low-level switch;
+- interrupt-return mechanics;
+- user/kernel transition details.
+
+## Boot protocols
+
+Limine is an adapter, not the kernel's internal boot model.
+
+```text
+Limine structures
+      ↓ validate and normalize
+kernel boot_info
+      ↓ consumed by
+PMM, framebuffer, modules, firmware discovery
+```
+
+No subsystem outside the boot adapter should include `limine.h`.
+
+## Firmware and hardware description
+
+UEFI is used for the initial boot, while ACPI will describe relevant x86_64 hardware.
+
+Generic code should receive discovered resources through normalized models. For example, the interrupt-controller subsystem should not parse ACPI itself. ACPI parsing discovers controllers and passes validated descriptions to their drivers.
+
+## Drivers
+
+Prefer capability-oriented interfaces over architecture names.
+
+Examples:
+
+- byte-output sink;
+- interrupt controller;
+- clock source;
+- clock event device;
+- framebuffer;
+- block device;
+- network device.
+
+The early serial driver may be x86_64/QEMU-specific, but logging only sees a byte-output sink.
+
+## Build-system abstraction
+
+The build configuration should select:
+
+- architecture sources;
+- architecture compiler flags;
+- linker script;
+- boot image strategy;
+- emulator arguments;
+- debugger architecture;
+- firmware assets.
+
+A future architecture should add configuration and backend code rather than fork all build logic.
+
+## Abstraction review checklist
+
+Before merging a subsystem:
+
+- [ ] Does generic code include an architecture-specific header unnecessarily?
+- [ ] Are hardware bit positions leaking into generic enums?
+- [ ] Is a bootloader structure stored beyond early boot?
+- [ ] Is a physical address being treated as a dereferenceable pointer?
+- [ ] Does a scheduler or VM policy function execute x86 assembly directly?
+- [ ] Is a platform-specific name used for a generic concept?
+- [ ] Is the proposed interface based on a real current requirement?
+- [ ] Could a host-side fake backend test the generic logic?
+- [ ] Are failure semantics documented?
+- [ ] Is the abstraction smaller than the implementation it hides?
+
+## Avoid false portability
+
+Do not:
+
+- implement empty ARM64 or RISC-V directories merely to claim portability;
+- add callbacks for every imaginable architecture feature;
+- use preprocessor conditionals throughout generic code;
+- pretend x86 segmentation and ARM exception levels are identical;
+- erase useful platform information from diagnostics;
+- optimize for a second architecture before the first backend is correct.
+
+## Future validation strategy
+
+After M0–M11 are stable, choose one minimal validation target:
+
+- ARM64 under QEMU with UEFI, or
+- RISC-V 64 under QEMU with SBI/OpenSBI.
+
+The validation target only needs to reach selected milestones initially:
+
+1. build;
+2. boot;
+3. serial output;
+4. exceptions;
+5. physical memory discovery.
+
+Any abstraction that makes the second backend harder without making the first backend clearer should be reconsidered.

--- a/docs/new-project/PORTABILITY_AND_ABSTRACTION.md
+++ b/docs/new-project/PORTABILITY_AND_ABSTRACTION.md
@@ -1,16 +1,16 @@
-# Portability and Abstraction Strategy
+# Strategia di portabilità e astrazione
 
-The project starts on **x86_64 in 64-bit mode**, but the codebase should avoid turning x86_64 mechanisms into universal kernel concepts.
+Il progetto parte da **x86_64 in modalità a 64 bit**, ma il codice non deve trasformare i meccanismi x86_64 in concetti universali del kernel.
 
-The goal is not immediate multi-architecture support. The goal is to preserve clear boundaries so that a future backend can be added without rewriting the generic kernel.
+L’obiettivo non è supportare subito più architetture. L’obiettivo è mantenere confini chiari, così che un backend futuro possa essere aggiunto senza riscrivere il kernel generico.
 
-## Core principle
+## Principio fondamentale
 
-> Abstract stable concepts, not hypothetical hardware.
+> Astrarre i concetti stabili, non l’hardware ipotetico.
 
-We should not invent a large universal HAL before understanding the needs of the first implementation. We should instead isolate direct hardware access, expose small contracts and revise those contracts only when concrete evidence requires it.
+Non va progettata in anticipo una HAL universale e molto estesa. È preferibile isolare l’accesso diretto all’hardware, esporre contratti piccoli e modificarli solo quando requisiti concreti lo richiedono.
 
-## Source-tree boundary
+## Confine nell’albero dei sorgenti
 
 ```text
 kernel/
@@ -34,83 +34,72 @@ kernel/
 └── lib/
 ```
 
-The exact layout may evolve, but these ownership rules should remain:
+Regole di proprietà:
 
-- `arch/x86_64` owns instructions, registers, descriptor tables and page-table formats;
-- generic memory management owns allocation and mapping policy;
-- generic scheduling owns thread states and policy;
-- architecture code owns low-level context switching;
-- boot-protocol adapters own Limine structures;
-- generic kernel code consumes normalized boot information;
-- device-independent code consumes interfaces, not APIC or COM1 registers.
+- `arch/x86_64` possiede istruzioni, registri, descriptor table e formati delle page table;
+- la memoria generica possiede politiche di allocazione e mapping;
+- lo scheduler generico possiede stati e politiche dei thread;
+- il backend architetturale possiede il context switch low-level;
+- gli adapter di boot possiedono le strutture Limine;
+- il kernel generico consuma informazioni di boot normalizzate;
+- il codice indipendente dai device usa interfacce, non registri APIC o COM1.
 
-## What must remain architecture-specific
+## Elementi specifici dell’architettura
 
-- entry assembly;
-- CPU feature detection;
-- control-register access;
-- MSR access;
-- exception and interrupt stubs;
-- GDT, TSS and IDT construction;
-- page-table entry encoding;
-- TLB invalidation instructions;
-- context-switch assembly;
-- privilege transition assembly;
-- syscall entry assembly;
-- port IO;
-- architecture-specific barriers;
-- APIC register access.
+- assembly di ingresso;
+- rilevamento delle feature CPU;
+- accesso a control register e MSR;
+- stub di eccezioni e interrupt;
+- costruzione di GDT, TSS e IDT;
+- codifica delle entry delle page table;
+- istruzioni di invalidazione TLB;
+- assembly di context switch;
+- transizioni di privilegio;
+- ingresso delle syscall;
+- port I/O;
+- memory barrier specifiche;
+- accesso ai registri APIC.
 
-## What should be generic
+## Elementi generici
 
-- log formatting and routing;
-- panic policy;
-- normalized exception reporting;
-- physical-page ownership;
-- allocation policy;
-- address-space lifecycle;
-- generic mapping permissions;
-- heap allocation;
-- scheduler policy and queues;
-- thread and process state;
-- syscall semantics;
-- ELF parsing framework;
-- VFS;
-- file descriptors;
-- initramfs archive handling;
-- tests for pure algorithms and parsers.
+- formattazione e routing dei log;
+- politica di panic;
+- reporting normalizzato delle eccezioni;
+- proprietà delle pagine fisiche;
+- politiche di allocazione;
+- ciclo di vita degli address space;
+- permessi di mapping generici;
+- heap;
+- code e politica dello scheduler;
+- stato di thread e processi;
+- semantica delle syscall;
+- framework di parsing ELF;
+- VFS e file descriptor;
+- gestione dell’archivio initramfs;
+- test di algoritmi e parser puri.
 
-## Address types
+## Tipi di indirizzo
 
-Avoid passing unlabelled integers when the address domain matters.
+Evitare interi privi di significato quando il dominio dell’indirizzo è importante:
 
 ```c
-typedef struct {
-    uintptr_t value;
-} paddr_t;
-
-typedef struct {
-    uintptr_t value;
-} vaddr_t;
+typedef struct { uintptr_t value; } paddr_t;
+typedef struct { uintptr_t value; } vaddr_t;
 ```
 
-These wrappers prevent accidental mixing and allow architecture-specific validation at boundaries.
-
-Operations should be explicit:
+Le operazioni devono essere esplicite:
 
 ```c
 [[nodiscard]] bool paddr_add(paddr_t base, size_t offset, paddr_t *out);
 [[nodiscard]] bool vaddr_add(vaddr_t base, size_t offset, vaddr_t *out);
 ```
 
-## CPU context
+## Contesto CPU
 
-Do not force one universal register structure on every subsystem.
+Non imporre un’unica struttura universale dei registri. Usare due livelli:
 
-Use two layers:
-
-1. an architecture-owned raw context containing exact saved registers;
-2. a generic diagnostic view containing common fields and accessors.
+1. un contesto grezzo posseduto dall’architettura;
+2. una vista diagnostica generica.
 
 ```c
 struct arch_cpu_context;
@@ -123,11 +112,11 @@ struct execution_view {
 };
 ```
 
-The architecture backend converts or exposes accessors without discarding raw information.
+Il backend conserva sempre le informazioni specifiche complete.
 
-## Exceptions
+## Eccezioni
 
-Generic code should reason about categories:
+Il codice generico ragiona per categorie:
 
 ```c
 enum exception_class {
@@ -140,11 +129,11 @@ enum exception_class {
 };
 ```
 
-The x86_64 backend retains the vector number and architecture-specific error code.
+Il backend x86_64 conserva vettore e codice d’errore specifico.
 
-## Virtual memory
+## Memoria virtuale
 
-Generic VM permissions must not match x86_64 page-table bits by accident.
+I permessi generici non devono coincidere accidentalmente con i bit x86_64:
 
 ```c
 enum vm_permission {
@@ -156,15 +145,11 @@ enum vm_permission {
 };
 ```
 
-The x86_64 backend translates these into present, writable, user, global and NX semantics.
+Il backend traduce questi valori nei bit present, writable, user, global e NX. La dimensione delle pagine deve provenire dal contratto dell’architettura o dalla configurazione del target, non da costanti duplicate.
 
-Page size should be obtained through the architecture contract or build-time target description rather than repeated as a magic constant.
+## Interrupt
 
-## Interrupts
-
-Generic interrupt dispatch should not assume that every platform uses numbered IDT vectors.
-
-A generic interrupt source can contain an opaque platform identifier:
+Il dispatch generico non deve assumere che ogni piattaforma usi vettori IDT numerati.
 
 ```c
 struct interrupt_source {
@@ -172,127 +157,98 @@ struct interrupt_source {
 };
 ```
 
-Registration, masking and acknowledgement are operations supplied by the controller backend.
+Registrazione, masking e acknowledgement sono operazioni del backend del controller. Il primo backend può mappare direttamente l’identificatore su vettori x86_64 e route IOAPIC.
 
-The first backend may map this directly to x86_64 vectors and IOAPIC entries.
+## Tempo
 
-## Time
+Separare:
 
-Separate:
+- **clock source**: valore che avanza continuamente;
+- **clock event device**: programma un interrupt futuro;
+- **timekeeping del kernel**: converte e accumula il tempo;
+- **politica dello scheduler**: decide come usare il tempo.
 
-- **clock source**: reads a continuously advancing value;
-- **clock event device**: asks hardware to interrupt at or after a deadline;
-- **kernel timekeeping**: converts and accumulates time;
-- **scheduler tick policy**: decides how the scheduler uses time.
-
-Do not let the scheduler read LAPIC or TSC registers directly.
+Lo scheduler non deve leggere direttamente LAPIC o TSC.
 
 ## Scheduler
 
-The generic scheduler owns:
+Il livello generico possiede stati, run queue, politica, blocco/risveglio e durata dei thread. Il backend architetturale possiede contesto iniziale, switch low-level e transizioni kernel/utente.
 
-- thread states;
-- run queues;
-- policy;
-- block/wake transitions;
-- lifetime rules.
+## Protocolli di boot
 
-The architecture backend owns:
-
-- initial register context;
-- low-level switch;
-- interrupt-return mechanics;
-- user/kernel transition details.
-
-## Boot protocols
-
-Limine is an adapter, not the kernel's internal boot model.
+Limine è un adapter, non il modello interno del kernel:
 
 ```text
-Limine structures
-      ↓ validate and normalize
-kernel boot_info
-      ↓ consumed by
-PMM, framebuffer, modules, firmware discovery
+strutture Limine
+      ↓ validazione e normalizzazione
+boot_info del kernel
+      ↓
+PMM, framebuffer, moduli, firmware
 ```
 
-No subsystem outside the boot adapter should include `limine.h`.
+Nessun sottosistema esterno all’adapter deve includere `limine.h`.
 
-## Firmware and hardware description
+## Firmware e descrizione hardware
 
-UEFI is used for the initial boot, while ACPI will describe relevant x86_64 hardware.
+UEFI viene usato per il boot iniziale; ACPI descrive l’hardware x86_64 rilevante. I parser di ACPI producono modelli validati e normalizzati: i driver dei controller non devono analizzare direttamente le tabelle firmware.
 
-Generic code should receive discovered resources through normalized models. For example, the interrupt-controller subsystem should not parse ACPI itself. ACPI parsing discovers controllers and passes validated descriptions to their drivers.
+## Driver
 
-## Drivers
+Preferire interfacce basate sulle capacità:
 
-Prefer capability-oriented interfaces over architecture names.
-
-Examples:
-
-- byte-output sink;
-- interrupt controller;
+- sink di output byte;
+- controller interrupt;
 - clock source;
 - clock event device;
 - framebuffer;
 - block device;
 - network device.
 
-The early serial driver may be x86_64/QEMU-specific, but logging only sees a byte-output sink.
+Il driver seriale iniziale può essere specifico di x86_64/QEMU, mentre il logger vede soltanto un sink di byte.
 
-## Build-system abstraction
+## Astrazione del build system
 
-The build configuration should select:
+La configurazione seleziona:
 
-- architecture sources;
-- architecture compiler flags;
+- sorgenti dell’architettura;
+- flag specifici;
 - linker script;
-- boot image strategy;
-- emulator arguments;
-- debugger architecture;
-- firmware assets.
+- strategia dell’immagine di boot;
+- argomenti dell’emulatore;
+- architettura del debugger;
+- asset firmware.
 
-A future architecture should add configuration and backend code rather than fork all build logic.
+Una nuova architettura deve aggiungere configurazione e backend, non duplicare tutta la build.
 
-## Abstraction review checklist
+## Checklist di revisione delle astrazioni
 
-Before merging a subsystem:
+- [ ] Il codice generico include inutilmente header specifici?
+- [ ] Bit hardware trapelano in enum generici?
+- [ ] Una struttura del bootloader sopravvive oltre l’early boot?
+- [ ] Un indirizzo fisico viene trattato come puntatore dereferenziabile?
+- [ ] Scheduler o VM generici eseguono assembly x86?
+- [ ] Un nome specifico viene usato per un concetto generico?
+- [ ] L’interfaccia risponde a un requisito reale?
+- [ ] Un backend finto host-side può testare la logica?
+- [ ] La semantica degli errori è documentata?
+- [ ] L’astrazione è più piccola dell’implementazione che nasconde?
 
-- [ ] Does generic code include an architecture-specific header unnecessarily?
-- [ ] Are hardware bit positions leaking into generic enums?
-- [ ] Is a bootloader structure stored beyond early boot?
-- [ ] Is a physical address being treated as a dereferenceable pointer?
-- [ ] Does a scheduler or VM policy function execute x86 assembly directly?
-- [ ] Is a platform-specific name used for a generic concept?
-- [ ] Is the proposed interface based on a real current requirement?
-- [ ] Could a host-side fake backend test the generic logic?
-- [ ] Are failure semantics documented?
-- [ ] Is the abstraction smaller than the implementation it hides?
+## Evitare la falsa portabilità
 
-## Avoid false portability
+Non bisogna:
 
-Do not:
+- creare directory ARM64 o RISC-V vuote solo per dichiarare portabilità;
+- aggiungere callback per ogni feature immaginabile;
+- disseminare `#ifdef` nel codice generico;
+- fingere che segmentazione x86 e livelli di eccezione ARM siano identici;
+- eliminare informazioni specifiche utili dalla diagnostica;
+- ottimizzare per una seconda architettura prima che la prima sia corretta.
 
-- implement empty ARM64 or RISC-V directories merely to claim portability;
-- add callbacks for every imaginable architecture feature;
-- use preprocessor conditionals throughout generic code;
-- pretend x86 segmentation and ARM exception levels are identical;
-- erase useful platform information from diagnostics;
-- optimize for a second architecture before the first backend is correct.
+## Validazione futura
 
-## Future validation strategy
+Dopo la stabilizzazione di M0–M11 verrà scelto un target minimo:
 
-After M0–M11 are stable, choose one minimal validation target:
+- ARM64 sotto QEMU con UEFI, oppure
+- RISC-V 64 sotto QEMU con SBI/OpenSBI.
 
-- ARM64 under QEMU with UEFI, or
-- RISC-V 64 under QEMU with SBI/OpenSBI.
-
-The validation target only needs to reach selected milestones initially:
-
-1. build;
-2. boot;
-3. serial output;
-4. exceptions;
-5. physical memory discovery.
-
-Any abstraction that makes the second backend harder without making the first backend clearer should be reconsidered.
+Il secondo backend dovrà inizialmente raggiungere solo build, boot, seriale, eccezioni e scoperta della memoria fisica. Qualunque astrazione renda il secondo backend più difficile senza chiarire il primo dovrà essere rivalutata.

--- a/docs/new-project/README.md
+++ b/docs/new-project/README.md
@@ -1,81 +1,81 @@
-# New OS Project — Documentation
+# Nuovo progetto OS — Documentazione
 
-This directory contains the initial design documents for a new educational operating-system project built from scratch after Zone OS.
+Questa directory contiene i documenti iniziali di progettazione di un nuovo sistema operativo educativo costruito da zero dopo Zone OS.
 
-The project has two equal goals:
+Il progetto ha due obiettivi di pari importanza:
 
-1. build a small, understandable and progressively testable 64-bit operating system;
-2. produce a complete Italian YouTube series that explains every important technical decision.
+1. costruire un sistema operativo a 64 bit piccolo, comprensibile e verificabile in modo progressivo;
+2. produrre una serie completa di video YouTube in italiano che spieghi ogni decisione tecnica importante.
 
-The first implementation target is x86_64, but architecture-specific mechanisms must remain behind small, explicit interfaces. Portability is treated as a design discipline rather than an immediate promise of multiple complete backends.
+La prima implementazione è destinata a x86_64, ma i meccanismi specifici dell’architettura devono rimanere dietro interfacce piccole ed esplicite. La portabilità viene trattata come disciplina progettuale, non come promessa immediata di più backend completi.
 
-## Documents
+## Documenti
 
-### Direction and architecture
+### Direzione e architettura
 
-- [Vision and goals](VISION.md)
-- [Architecture](ARCHITECTURE.md)
-- [Portability and abstraction strategy](PORTABILITY_AND_ABSTRACTION.md)
-- [Architecture decision records](DECISIONS.md)
+- [Visione e obiettivi](VISION.md)
+- [Architettura](ARCHITECTURE.md)
+- [Strategia di portabilità e astrazione](PORTABILITY_AND_ABSTRACTION.md)
+- [Decisioni architetturali](DECISIONS.md)
 
-### Planning and learning
+### Pianificazione e apprendimento
 
-- [Roadmap and milestones](ROADMAP.md)
-- [Detailed milestone goals and checklists](MILESTONES_DETAILED.md)
-- [OS development study plan](STUDY_PLAN.md)
-- [YouTube series plan](YOUTUBE_SERIES.md)
+- [Roadmap e milestone](ROADMAP.md)
+- [Obiettivi dettagliati e checklist delle milestone](MILESTONES_DETAILED.md)
+- [Piano di studio per lo sviluppo OS](STUDY_PLAN.md)
+- [Piano della serie YouTube](YOUTUBE_SERIES.md)
 
-### Engineering process
+### Processo ingegneristico
 
-- [Build system](BUILD_SYSTEM.md)
-- [C23 language policy](C23_POLICY.md)
-- [Development workflow](DEVELOPMENT_WORKFLOW.md)
-- [Testing strategy](TESTING.md)
+- [Sistema di build](BUILD_SYSTEM.md)
+- [Politica del linguaggio C23](C23_POLICY.md)
+- [Flusso di sviluppo](DEVELOPMENT_WORKFLOW.md)
+- [Strategia di test](TESTING.md)
 
-## Working principles
+## Principi operativi
 
-- Correctness before features.
-- Observability before complexity.
-- One testable result per milestone.
-- One focused change per pull request.
-- The repository must remain understandable from the first episode to the latest one.
-- Every major decision must be documented.
-- The build must be incremental, reproducible and easy to explain.
-- Generic code must not manipulate x86_64 registers or hardware formats directly.
-- Architecture abstractions must be driven by real requirements, not speculative portability.
-- Every milestone includes a study track, success tests and deliberate failure tests.
+- Correttezza prima delle funzionalità.
+- Osservabilità prima della complessità.
+- Un risultato verificabile per ogni milestone.
+- Una modifica focalizzata per ogni pull request.
+- Il repository deve restare comprensibile dal primo episodio all’ultimo.
+- Ogni decisione importante deve essere documentata.
+- La build deve essere incrementale, riproducibile e facile da spiegare.
+- Il codice generico non deve manipolare direttamente registri o formati hardware x86_64.
+- Le astrazioni devono derivare da requisiti reali, non da portabilità speculativa.
+- Ogni milestone include un percorso di studio, test di successo e test deliberati di errore.
 
-## Initial technical direction
+## Direzione tecnica iniziale
 
-- Architecture: x86_64, 64-bit mode only.
-- Architecture strategy: generic kernel contracts with an initial x86_64 backend.
-- Boot protocol: Limine adapter feeding kernel-owned boot information.
-- Initial firmware target: UEFI.
-- Kernel design: monolithic but modular.
-- Language: ISO C23, freestanding.
-- Compiler: Clang as primary compiler.
+- Architettura: x86_64, esclusivamente modalità a 64 bit.
+- Strategia: contratti kernel generici con backend iniziale x86_64.
+- Protocollo di boot: adapter Limine che produce informazioni di boot possedute dal kernel.
+- Firmware iniziale: UEFI.
+- Design del kernel: monolitico ma modulare.
+- Linguaggio: ISO C23 freestanding.
+- Compilatore principale: Clang.
 - Linker: LLD.
-- Build system: Meson and Ninja.
-- Emulator: QEMU.
+- Build system: Meson e Ninja.
+- Emulatore: QEMU.
 - Debugger: GDB.
-- Primary diagnostic output: serial console.
-- Container usage: optional for development, required for reproducible CI images.
+- Diagnostica primaria: console seriale.
+- Container: opzionale nello sviluppo, richiesto come ambiente riproducibile di riferimento in CI.
 
-## Initial milestone sequence
+## Sequenza iniziale delle milestone
 
-1. Reproducible 64-bit workspace.
-2. Controlled UEFI boot.
-3. Diagnostics and CPU exceptions.
-4. Physical memory ownership.
-5. Virtual address spaces.
-6. Kernel dynamic memory.
-7. Interrupt delivery and time.
-8. Kernel threads and scheduling.
-9. User execution domain.
-10. System-call boundary.
-11. Initramfs and ELF64 program loading.
-12. Minimal VFS.
+1. Workspace a 64 bit riproducibile.
+2. Boot UEFI controllato.
+3. Diagnostica ed eccezioni CPU.
+4. Proprietà della memoria fisica.
+5. Spazi di indirizzamento virtuale.
+6. Memoria dinamica del kernel.
+7. Consegna degli interrupt e gestione del tempo.
+8. Thread kernel e scheduling.
+9. Dominio di esecuzione utente.
+10. Confine delle chiamate di sistema.
+11. Initramfs e caricamento di programmi ELF64.
+12. VFS minimale.
 
-Each milestone has detailed deliverables, verification checklists and exit criteria in [MILESTONES_DETAILED.md](MILESTONES_DETAILED.md). The associated knowledge path is defined in [STUDY_PLAN.md](STUDY_PLAN.md).
+Ogni milestone possiede deliverable, checklist di verifica e criteri d’uscita in [MILESTONES_DETAILED.md](MILESTONES_DETAILED.md). Il percorso di conoscenze associato è definito in [STUDY_PLAN.md](STUDY_PLAN.md).
 
-This documentation is intentionally stored in Zone OS temporarily. The final project should live in a separate repository once its name and repository are created.
+Questa documentazione è conservata temporaneamente in Zone OS. Il progetto definitivo dovrà vivere in un repository separato dopo la scelta del nome e la creazione del repository.

--- a/docs/new-project/README.md
+++ b/docs/new-project/README.md
@@ -9,12 +9,15 @@ Il progetto ha due obiettivi di pari importanza:
 
 La prima implementazione è destinata a x86_64, ma i meccanismi specifici dell’architettura devono rimanere dietro interfacce piccole ed esplicite. La portabilità viene trattata come disciplina progettuale, non come promessa immediata di più backend completi.
 
+Il kernel segue una strategia **ibrida evolutiva**: parte come monolitico modulare per mantenere semplice lo sviluppo iniziale, ma separa fin dall'inizio strutture, ownership, API e protocolli in modo da poter spostare progressivamente filesystem, driver e altri servizi in user space.
+
 ## Documenti
 
 ### Direzione e architettura
 
 - [Visione e obiettivi](VISION.md)
 - [Architettura](ARCHITECTURE.md)
+- [Strategia del kernel ibrido evolutivo](HYBRID_KERNEL_STRATEGY.md)
 - [Strategia di portabilità e astrazione](PORTABILITY_AND_ABSTRACTION.md)
 - [Decisioni architetturali](DECISIONS.md)
 
@@ -44,6 +47,9 @@ La prima implementazione è destinata a x86_64, ma i meccanismi specifici dell�
 - Il codice generico non deve manipolare direttamente registri o formati hardware x86_64.
 - Le astrazioni devono derivare da requisiti reali, non da portabilità speculativa.
 - Ogni milestone include un percorso di studio, test di successo e test deliberati di errore.
+- Le strutture interne dei sottosistemi sono private e vengono esposte tramite tipi opachi.
+- Le API candidate a diventare remote usano handle, errori stabili e buffer con ownership esplicita.
+- Un servizio deve poter avere un backend locale e, in seguito, un proxy IPC con la stessa semantica.
 
 ## Direzione tecnica iniziale
 
@@ -51,7 +57,8 @@ La prima implementazione è destinata a x86_64, ma i meccanismi specifici dell�
 - Strategia: contratti kernel generici con backend iniziale x86_64.
 - Protocollo di boot: adapter Limine che produce informazioni di boot possedute dal kernel.
 - Firmware iniziale: UEFI.
-- Design del kernel: monolitico ma modulare.
+- Design del kernel: ibrido evolutivo, inizialmente monolitico modulare.
+- IPC: introdotto prima del filesystem persistente e dell'estrazione dei driver.
 - Linguaggio: ISO C23 freestanding.
 - Compilatore principale: Clang.
 - Linker: LLD.
@@ -72,9 +79,11 @@ La prima implementazione è destinata a x86_64, ma i meccanismi specifici dell�
 7. Consegna degli interrupt e gestione del tempo.
 8. Thread kernel e scheduling.
 9. Dominio di esecuzione utente.
-10. Confine delle chiamate di sistema.
-11. Initramfs e caricamento di programmi ELF64.
-12. VFS minimale.
+10. IPC, handle e condivisione controllata della memoria.
+11. Confine delle chiamate di sistema.
+12. Initramfs e caricamento di programmi ELF64.
+13. VFS minimale con backend locale sostituibile.
+14. Primo servizio user space sperimentale.
 
 Ogni milestone possiede deliverable, checklist di verifica e criteri d’uscita in [MILESTONES_DETAILED.md](MILESTONES_DETAILED.md). Il percorso di conoscenze associato è definito in [STUDY_PLAN.md](STUDY_PLAN.md).
 

--- a/docs/new-project/README.md
+++ b/docs/new-project/README.md
@@ -1,0 +1,47 @@
+# New OS Project — Documentation
+
+This directory contains the initial design documents for a new educational operating-system project built from scratch after Zone OS.
+
+The project has two equal goals:
+
+1. build a small, understandable and progressively testable x86_64 operating system;
+2. produce a complete Italian YouTube series that explains every important technical decision.
+
+## Documents
+
+- [Vision and goals](VISION.md)
+- [Architecture](ARCHITECTURE.md)
+- [Roadmap and milestones](ROADMAP.md)
+- [Build system](BUILD_SYSTEM.md)
+- [C23 language policy](C23_POLICY.md)
+- [Development workflow](DEVELOPMENT_WORKFLOW.md)
+- [Testing strategy](TESTING.md)
+- [YouTube series plan](YOUTUBE_SERIES.md)
+- [Architecture decision records](DECISIONS.md)
+
+## Working principles
+
+- Correctness before features.
+- Observability before complexity.
+- One testable result per milestone.
+- One focused change per pull request.
+- The repository must remain understandable from the first episode to the latest one.
+- Every major decision must be documented.
+- The build must be incremental, reproducible and easy to explain.
+
+## Initial technical direction
+
+- Architecture: x86_64 only.
+- Boot protocol: Limine.
+- Initial firmware target: UEFI.
+- Kernel design: monolithic but modular.
+- Language: ISO C23, freestanding.
+- Compiler: Clang as primary compiler.
+- Linker: LLD.
+- Build system: Meson and Ninja.
+- Emulator: QEMU.
+- Debugger: GDB.
+- Primary diagnostic output: serial console.
+- Container usage: optional for development, required for reproducible CI images.
+
+This documentation is intentionally stored in Zone OS temporarily. The final project should live in a separate repository once its name and repository are created.

--- a/docs/new-project/README.md
+++ b/docs/new-project/README.md
@@ -25,6 +25,7 @@ Il kernel segue una strategia **ibrida evolutiva**: parte come monolitico modula
 
 - [Roadmap e milestone](ROADMAP.md)
 - [Obiettivi dettagliati e checklist delle milestone](MILESTONES_DETAILED.md)
+- [Roadmap delle API per milestone](API_ROADMAP.md)
 - [Piano di studio per lo sviluppo OS](STUDY_PLAN.md)
 - [Piano della serie YouTube](YOUTUBE_SERIES.md)
 
@@ -47,6 +48,7 @@ Il kernel segue una strategia **ibrida evolutiva**: parte come monolitico modula
 - Il codice generico non deve manipolare direttamente registri o formati hardware x86_64.
 - Le astrazioni devono derivare da requisiti reali, non da portabilità speculativa.
 - Ogni milestone include un percorso di studio, test di successo e test deliberati di errore.
+- Ogni milestone definisce prima dell'implementazione le API pubbliche previste, con firme, ownership, errori e test richiesti.
 - Le strutture interne dei sottosistemi sono private e vengono esposte tramite tipi opachi.
 - Le API candidate a diventare remote usano handle, errori stabili e buffer con ownership esplicita.
 - Un servizio deve poter avere un backend locale e, in seguito, un proxy IPC con la stessa semantica.
@@ -85,6 +87,6 @@ Il kernel segue una strategia **ibrida evolutiva**: parte come monolitico modula
 13. VFS minimale con backend locale sostituibile.
 14. Primo servizio user space sperimentale.
 
-Ogni milestone possiede deliverable, checklist di verifica e criteri d’uscita in [MILESTONES_DETAILED.md](MILESTONES_DETAILED.md). Il percorso di conoscenze associato è definito in [STUDY_PLAN.md](STUDY_PLAN.md).
+Ogni milestone possiede deliverable, checklist di verifica e criteri d’uscita in [MILESTONES_DETAILED.md](MILESTONES_DETAILED.md). Le firme previste sono raccolte in [API_ROADMAP.md](API_ROADMAP.md), mentre il percorso di conoscenze associato è definito in [STUDY_PLAN.md](STUDY_PLAN.md).
 
 Questa documentazione è conservata temporaneamente in Zone OS. Il progetto definitivo dovrà vivere in un repository separato dopo la scelta del nome e la creazione del repository.

--- a/docs/new-project/README.md
+++ b/docs/new-project/README.md
@@ -4,20 +4,33 @@ This directory contains the initial design documents for a new educational opera
 
 The project has two equal goals:
 
-1. build a small, understandable and progressively testable x86_64 operating system;
+1. build a small, understandable and progressively testable 64-bit operating system;
 2. produce a complete Italian YouTube series that explains every important technical decision.
+
+The first implementation target is x86_64, but architecture-specific mechanisms must remain behind small, explicit interfaces. Portability is treated as a design discipline rather than an immediate promise of multiple complete backends.
 
 ## Documents
 
+### Direction and architecture
+
 - [Vision and goals](VISION.md)
 - [Architecture](ARCHITECTURE.md)
+- [Portability and abstraction strategy](PORTABILITY_AND_ABSTRACTION.md)
+- [Architecture decision records](DECISIONS.md)
+
+### Planning and learning
+
 - [Roadmap and milestones](ROADMAP.md)
+- [Detailed milestone goals and checklists](MILESTONES_DETAILED.md)
+- [OS development study plan](STUDY_PLAN.md)
+- [YouTube series plan](YOUTUBE_SERIES.md)
+
+### Engineering process
+
 - [Build system](BUILD_SYSTEM.md)
 - [C23 language policy](C23_POLICY.md)
 - [Development workflow](DEVELOPMENT_WORKFLOW.md)
 - [Testing strategy](TESTING.md)
-- [YouTube series plan](YOUTUBE_SERIES.md)
-- [Architecture decision records](DECISIONS.md)
 
 ## Working principles
 
@@ -28,11 +41,15 @@ The project has two equal goals:
 - The repository must remain understandable from the first episode to the latest one.
 - Every major decision must be documented.
 - The build must be incremental, reproducible and easy to explain.
+- Generic code must not manipulate x86_64 registers or hardware formats directly.
+- Architecture abstractions must be driven by real requirements, not speculative portability.
+- Every milestone includes a study track, success tests and deliberate failure tests.
 
 ## Initial technical direction
 
-- Architecture: x86_64 only.
-- Boot protocol: Limine.
+- Architecture: x86_64, 64-bit mode only.
+- Architecture strategy: generic kernel contracts with an initial x86_64 backend.
+- Boot protocol: Limine adapter feeding kernel-owned boot information.
 - Initial firmware target: UEFI.
 - Kernel design: monolithic but modular.
 - Language: ISO C23, freestanding.
@@ -43,5 +60,22 @@ The project has two equal goals:
 - Debugger: GDB.
 - Primary diagnostic output: serial console.
 - Container usage: optional for development, required for reproducible CI images.
+
+## Initial milestone sequence
+
+1. Reproducible 64-bit workspace.
+2. Controlled UEFI boot.
+3. Diagnostics and CPU exceptions.
+4. Physical memory ownership.
+5. Virtual address spaces.
+6. Kernel dynamic memory.
+7. Interrupt delivery and time.
+8. Kernel threads and scheduling.
+9. User execution domain.
+10. System-call boundary.
+11. Initramfs and ELF64 program loading.
+12. Minimal VFS.
+
+Each milestone has detailed deliverables, verification checklists and exit criteria in [MILESTONES_DETAILED.md](MILESTONES_DETAILED.md). The associated knowledge path is defined in [STUDY_PLAN.md](STUDY_PLAN.md).
 
 This documentation is intentionally stored in Zone OS temporarily. The final project should live in a separate repository once its name and repository are created.

--- a/docs/new-project/ROADMAP.md
+++ b/docs/new-project/ROADMAP.md
@@ -1,0 +1,170 @@
+# Roadmap and Milestones
+
+Each milestone must end with an observable result, automated verification where practical, updated documentation and a tagged repository state.
+
+## M0 — Reproducible workspace
+
+Deliverables:
+
+- Meson cross file for x86_64;
+- Ninja incremental build;
+- Clang and LLD toolchain configuration;
+- dependency checker;
+- debug and release build directories;
+- QEMU launcher;
+- GDB launcher;
+- CI build job.
+
+Completion criteria:
+
+- a clean clone can be configured with one documented command;
+- changing one C source recompiles only that translation unit and relinks;
+- build output never modifies the source tree.
+
+## M1 — Controlled UEFI boot
+
+Deliverables:
+
+- Limine configuration;
+- kernel ELF;
+- UEFI boot image;
+- validated bootloader requests;
+- serial initialization;
+- controlled halt path.
+
+Observable result:
+
+```text
+[boot] kernel entered
+[boot] Limine responses validated
+[ok] controlled boot complete
+```
+
+## M2 — Diagnostics and CPU exceptions
+
+Deliverables:
+
+- structured logging;
+- panic interface;
+- GDT and TSS;
+- IDT;
+- handlers for CPU exceptions;
+- register dump;
+- page-fault error decoding;
+- basic stack trace.
+
+Completion criteria:
+
+- intentional divide-by-zero and page-fault tests produce deterministic diagnostics;
+- panic does not allocate memory.
+
+## M3 — Physical memory management
+
+Deliverables:
+
+- normalized memory map;
+- page reservation rules;
+- bitmap allocator;
+- single-page and contiguous-page allocation as separate APIs;
+- double-free detection in debug builds;
+- statistics and integrity checks.
+
+## M4 — Virtual memory management
+
+Deliverables:
+
+- page-table walking;
+- map, unmap and resolve operations;
+- direct physical map;
+- high-half kernel mappings;
+- NX support;
+- TLB invalidation;
+- independent address-space object.
+
+## M5 — Kernel dynamic memory
+
+Deliverables:
+
+- early bump allocator;
+- page-backed heap;
+- simple free-list allocation;
+- alignment support;
+- debug poisoning and guard checks;
+- host-side allocator tests where possible.
+
+Advanced buddy and slab allocators are postponed until measurements justify them.
+
+## M6 — Hardware interrupts and time
+
+Deliverables:
+
+- local APIC initialization;
+- IOAPIC routing;
+- legacy PIC disable path;
+- timer calibration;
+- periodic timer interrupts;
+- interrupt registration API.
+
+## M7 — Kernel threads
+
+Deliverables:
+
+- thread representation;
+- per-thread kernel stack;
+- context switching;
+- ready queue;
+- idle thread;
+- round-robin scheduling;
+- preemption;
+- blocked and terminated states.
+
+## M8 — User mode
+
+Deliverables:
+
+- Ring 3 entry and return;
+- user stack;
+- separate address space;
+- safe copy-to-user and copy-from-user primitives;
+- intentional user-fault isolation test.
+
+## M9 — System calls
+
+Deliverables:
+
+- documented syscall ABI;
+- syscall dispatch;
+- `write`, `exit` and `yield`;
+- pointer and length validation;
+- unknown-syscall behavior.
+
+## M10 — Initramfs and ELF programs
+
+Deliverables:
+
+- Limine module loading;
+- TAR initramfs reader;
+- ELF64 validation and loader;
+- initial process creation;
+- first user program.
+
+Observable result:
+
+```text
+hello from userspace
+```
+
+## M11 — Minimal VFS
+
+Deliverables:
+
+- vnode model;
+- path lookup;
+- file descriptors;
+- `/dev/console`;
+- initramfs mounted as root;
+- basic `open`, `read`, `write` and `close` interfaces.
+
+## Later milestones
+
+Potential later work includes synchronization primitives, pipes, SMP, storage, FAT or ext2, networking, a shell and graphics. These must not be scheduled until the initial user-space cycle is stable.

--- a/docs/new-project/ROADMAP.md
+++ b/docs/new-project/ROADMAP.md
@@ -1,170 +1,170 @@
-# Roadmap and Milestones
+# Roadmap e milestone
 
-Each milestone must end with an observable result, automated verification where practical, updated documentation and a tagged repository state.
+Ogni milestone deve terminare con un risultato osservabile, una verifica automatizzata quando possibile, documentazione aggiornata e uno stato del repository contrassegnato da un tag.
 
-## M0 — Reproducible workspace
+## M0 — Workspace riproducibile
 
-Deliverables:
+Deliverable:
 
-- Meson cross file for x86_64;
-- Ninja incremental build;
-- Clang and LLD toolchain configuration;
-- dependency checker;
-- debug and release build directories;
-- QEMU launcher;
-- GDB launcher;
-- CI build job.
+- cross file Meson per x86_64;
+- build incrementale con Ninja;
+- configurazione della toolchain Clang e LLD;
+- controllo delle dipendenze;
+- directory di build debug e release;
+- launcher QEMU;
+- launcher GDB;
+- job CI di compilazione.
 
-Completion criteria:
+Criteri di completamento:
 
-- a clean clone can be configured with one documented command;
-- changing one C source recompiles only that translation unit and relinks;
-- build output never modifies the source tree.
+- un clone pulito può essere configurato con un singolo comando documentato;
+- modificare un sorgente C ricompila solo la relativa translation unit e rilinka;
+- gli output di build non modificano mai l’albero dei sorgenti.
 
-## M1 — Controlled UEFI boot
+## M1 — Boot UEFI controllato
 
-Deliverables:
+Deliverable:
 
-- Limine configuration;
+- configurazione Limine;
 - kernel ELF;
-- UEFI boot image;
-- validated bootloader requests;
-- serial initialization;
-- controlled halt path.
+- immagine di boot UEFI;
+- richieste al bootloader validate;
+- inizializzazione seriale;
+- percorso di halt controllato.
 
-Observable result:
+Risultato osservabile:
 
 ```text
-[boot] kernel entered
-[boot] Limine responses validated
-[ok] controlled boot complete
+[boot] ingresso nel kernel
+[boot] risposte Limine validate
+[ok] boot controllato completato
 ```
 
-## M2 — Diagnostics and CPU exceptions
+## M2 — Diagnostica ed eccezioni CPU
 
-Deliverables:
+Deliverable:
 
-- structured logging;
-- panic interface;
-- GDT and TSS;
+- logging strutturato;
+- interfaccia panic;
+- GDT e TSS;
 - IDT;
-- handlers for CPU exceptions;
-- register dump;
-- page-fault error decoding;
-- basic stack trace.
+- handler delle eccezioni CPU;
+- dump dei registri;
+- decodifica degli errori di page fault;
+- stack trace basilare.
 
-Completion criteria:
+Criteri di completamento:
 
-- intentional divide-by-zero and page-fault tests produce deterministic diagnostics;
-- panic does not allocate memory.
+- test intenzionali di divisione per zero e page fault producono diagnostica deterministica;
+- il panic non alloca memoria.
 
-## M3 — Physical memory management
+## M3 — Gestione della memoria fisica
 
-Deliverables:
+Deliverable:
 
-- normalized memory map;
-- page reservation rules;
-- bitmap allocator;
-- single-page and contiguous-page allocation as separate APIs;
-- double-free detection in debug builds;
-- statistics and integrity checks.
+- memory map normalizzata;
+- regole di riserva delle pagine;
+- allocator bitmap;
+- API separate per pagina singola e pagine contigue;
+- rilevamento double-free nelle build debug;
+- statistiche e controlli d’integrità.
 
-## M4 — Virtual memory management
+## M4 — Gestione della memoria virtuale
 
-Deliverables:
+Deliverable:
 
-- page-table walking;
-- map, unmap and resolve operations;
+- attraversamento delle page table;
+- operazioni map, unmap e resolve;
 - direct physical map;
-- high-half kernel mappings;
-- NX support;
-- TLB invalidation;
-- independent address-space object.
+- mapping high-half del kernel;
+- supporto NX;
+- invalidazione TLB;
+- oggetto address space indipendente.
 
-## M5 — Kernel dynamic memory
+## M5 — Memoria dinamica del kernel
 
-Deliverables:
+Deliverable:
 
-- early bump allocator;
-- page-backed heap;
-- simple free-list allocation;
-- alignment support;
-- debug poisoning and guard checks;
-- host-side allocator tests where possible.
+- bump allocator iniziale;
+- heap sostenuto da pagine;
+- allocator semplice a free list;
+- supporto all’allineamento;
+- poisoning e controlli guard nelle build debug;
+- test host-side dell’allocator quando possibile.
 
-Advanced buddy and slab allocators are postponed until measurements justify them.
+Buddy e slab allocator avanzati vengono rimandati finché misure concrete non ne giustificano l’introduzione.
 
-## M6 — Hardware interrupts and time
+## M6 — Interrupt hardware e tempo
 
-Deliverables:
+Deliverable:
 
-- local APIC initialization;
-- IOAPIC routing;
-- legacy PIC disable path;
-- timer calibration;
-- periodic timer interrupts;
-- interrupt registration API.
+- inizializzazione Local APIC;
+- routing IOAPIC;
+- disattivazione del PIC legacy;
+- calibrazione del timer;
+- interrupt periodici del timer;
+- API di registrazione degli interrupt.
 
-## M7 — Kernel threads
+## M7 — Thread kernel
 
-Deliverables:
+Deliverable:
 
-- thread representation;
-- per-thread kernel stack;
+- rappresentazione dei thread;
+- stack kernel per thread;
 - context switching;
 - ready queue;
 - idle thread;
-- round-robin scheduling;
+- scheduling round-robin;
 - preemption;
-- blocked and terminated states.
+- stati bloccato e terminato.
 
-## M8 — User mode
+## M8 — Modalità utente
 
-Deliverables:
+Deliverable:
 
-- Ring 3 entry and return;
-- user stack;
-- separate address space;
-- safe copy-to-user and copy-from-user primitives;
-- intentional user-fault isolation test.
+- ingresso e ritorno da Ring 3;
+- stack utente;
+- address space separato;
+- primitive sicure `copy_to_user` e `copy_from_user`;
+- test intenzionale di isolamento di un fault utente.
 
-## M9 — System calls
+## M9 — Chiamate di sistema
 
-Deliverables:
+Deliverable:
 
-- documented syscall ABI;
-- syscall dispatch;
-- `write`, `exit` and `yield`;
-- pointer and length validation;
-- unknown-syscall behavior.
+- ABI syscall documentata;
+- dispatch delle syscall;
+- `write`, `exit` e `yield`;
+- validazione di puntatori e lunghezze;
+- comportamento per syscall sconosciute.
 
-## M10 — Initramfs and ELF programs
+## M10 — Initramfs e programmi ELF
 
-Deliverables:
+Deliverable:
 
-- Limine module loading;
-- TAR initramfs reader;
-- ELF64 validation and loader;
-- initial process creation;
-- first user program.
+- caricamento moduli Limine;
+- lettore initramfs TAR;
+- validazione e loader ELF64;
+- creazione del processo iniziale;
+- primo programma utente.
 
-Observable result:
+Risultato osservabile:
 
 ```text
-hello from userspace
+ciao dallo spazio utente
 ```
 
-## M11 — Minimal VFS
+## M11 — VFS minimale
 
-Deliverables:
+Deliverable:
 
-- vnode model;
-- path lookup;
-- file descriptors;
+- modello vnode;
+- risoluzione dei percorsi;
+- file descriptor;
 - `/dev/console`;
-- initramfs mounted as root;
-- basic `open`, `read`, `write` and `close` interfaces.
+- initramfs montata come root;
+- interfacce basilari `open`, `read`, `write` e `close`.
 
-## Later milestones
+## Milestone successive
 
-Potential later work includes synchronization primitives, pipes, SMP, storage, FAT or ext2, networking, a shell and graphics. These must not be scheduled until the initial user-space cycle is stable.
+Il lavoro futuro può includere primitive di sincronizzazione, pipe, SMP, storage, FAT o ext2, networking, shell e grafica. Queste attività non devono essere pianificate finché il ciclo iniziale dello user space non è stabile.

--- a/docs/new-project/STUDY_PLAN.md
+++ b/docs/new-project/STUDY_PLAN.md
@@ -1,660 +1,416 @@
-# OS Development Study Plan
+# Piano di studio per lo sviluppo di sistemi operativi
 
-This study plan follows the project milestones. It is not a prerequisite wall: study and implementation should alternate. Each topic should be learned deeply enough to explain it, implement a minimal version and debug common failures.
+Questo piano segue le milestone del progetto. Non è un muro di prerequisiti: studio e implementazione devono alternarsi. Ogni argomento va compreso abbastanza da poterlo spiegare, implementare in forma minima e debuggare nei casi di errore più comuni.
 
-The implementation begins on **x86_64 in 64-bit mode**, while the study plan separates universal operating-system concepts from x86_64-specific mechanisms.
+L’implementazione parte da **x86_64 in modalità a 64 bit**, distinguendo sempre i concetti universali dei sistemi operativi dai meccanismi specifici della prima architettura.
 
-## Study method for every milestone
+## Metodo di studio per ogni milestone
 
-For each subject:
+Per ogni argomento:
 
-1. learn the architecture-neutral concept;
-2. identify the contract the kernel needs;
-3. study the x86_64 mechanism used for the first backend;
-4. implement the smallest observable version;
-5. create success and failure tests;
-6. explain the result without hiding bootloader or hardware assumptions;
-7. write down what would change on another architecture.
+1. studiare il concetto indipendente dall’architettura;
+2. identificare il contratto richiesto dal kernel;
+3. studiare il meccanismo x86_64 usato dal primo backend;
+4. implementare la versione minima osservabile;
+5. creare test di successo e di errore;
+6. spiegare il risultato senza nascondere assunzioni hardware o del bootloader;
+7. annotare cosa cambierebbe su un’altra architettura.
 
-Each learning unit should produce:
+Ogni unità produce:
 
-- [ ] concise personal notes;
-- [ ] a diagram;
-- [ ] a glossary;
-- [ ] one minimal experiment;
-- [ ] one failure experiment;
-- [ ] one YouTube episode outline;
-- [ ] references to primary documentation.
+- [ ] note personali concise;
+- [ ] un diagramma;
+- [ ] un glossario;
+- [ ] un esperimento minimo;
+- [ ] un esperimento di fallimento;
+- [ ] una scaletta per un episodio;
+- [ ] riferimenti a documentazione primaria.
 
 ---
 
-# Foundation A — Modern freestanding C23
+# Fondamenta A — C23 moderno freestanding
 
-## Learn
+## Studiare
 
-- translation units;
-- declarations and definitions;
-- object lifetime and storage duration;
-- integer conversion and promotion rules;
-- pointer arithmetic;
-- alignment and padding;
-- strict aliasing and effective types;
-- undefined, unspecified and implementation-defined behavior;
-- volatile semantics and its limitations;
-- atomics at a conceptual level;
-- freestanding versus hosted implementations;
-- compiler builtins and extensions;
-- calling conventions and ABI boundaries.
+- translation unit, dichiarazioni e definizioni;
+- durata e lifetime degli oggetti;
+- conversioni e promozioni intere;
+- aritmetica dei puntatori;
+- allineamento e padding;
+- strict aliasing ed effective type;
+- comportamento undefined, unspecified e implementation-defined;
+- semantica e limiti di `volatile`;
+- concetti base degli atomici;
+- ambiente hosted e freestanding;
+- builtin ed estensioni del compilatore;
+- calling convention e confini ABI.
 
-## C23 features to use deliberately
+## C23 da usare consapevolmente
 
 - `static_assert`;
-- standard attributes such as `[[noreturn]]`, `[[nodiscard]]` and `[[maybe_unused]]`;
-- fixed-underlying-type enums where compiler support is verified;
-- `nullptr` where supported by the selected compiler baseline;
-- binary literals where they improve bit-field explanations;
-- checked and explicit integer operations.
+- `[[noreturn]]`, `[[nodiscard]]`, `[[maybe_unused]]`;
+- enum con tipo sottostante fisso quando verificato;
+- `nullptr` quando supportato dalla baseline;
+- letterali binari quando chiariscono i bit;
+- operazioni intere esplicite e controllate.
 
-## Exercises
+## Esercizi
 
-- [ ] Inspect structure layout with `sizeof`, `alignof` and `offsetof`.
-- [ ] Write overflow-safe alignment helpers.
-- [ ] Implement `memset`, `memcpy`, `memmove`, `memcmp` and `strlen`.
-- [ ] Test overlapping memory moves.
-- [ ] Demonstrate why signed overflow is not a wrapping operation.
-- [ ] Compare generated assembly for `volatile` and non-volatile accesses.
-- [ ] Create a compiler abstraction header for attributes and barriers.
+- [ ] ispezionare layout con `sizeof`, `alignof` e `offsetof`;
+- [ ] scrivere helper di allineamento protetti da overflow;
+- [ ] implementare `memset`, `memcpy`, `memmove`, `memcmp`, `strlen`;
+- [ ] testare copie sovrapposte;
+- [ ] dimostrare perché l’overflow signed non è wrapping garantito;
+- [ ] confrontare assembly con e senza `volatile`;
+- [ ] creare un header di astrazione del compilatore.
 
-## Completion signal
-
-You can explain why code that looks correct in C may still be invalid for a kernel because of undefined behavior, ABI assumptions or optimizer transformations.
+**Segnale di completamento:** saper spiegare perché codice C apparentemente corretto può essere invalido in un kernel per UB, ABI o trasformazioni dell’ottimizzatore.
 
 ---
 
-# Foundation B — Computer architecture
-
-## Architecture-neutral topics
-
-- privilege levels;
-- instruction execution and pipeline basics;
-- registers and processor state;
-- interrupts and exceptions;
-- virtual and physical addresses;
-- caches and memory hierarchy;
-- memory ordering;
-- MMIO versus port IO;
-- DMA concept;
-- multiprocessor basics;
-- firmware and hardware-description mechanisms.
-
-## x86_64 focus
-
-- general-purpose registers;
-- `RIP`, `RSP`, `RFLAGS`;
-- long mode;
-- canonical addresses;
-- control registers;
-- model-specific registers;
-- GDT, TSS and IDT;
-- paging hierarchy;
-- CPUID;
-- APIC family;
-- `syscall/sysret` and `iretq`;
-- System V AMD64 calling convention as a reference, not an unquestioned kernel ABI.
-
-## Exercises
-
-- [ ] Read and annotate a register dump.
-- [ ] Decode a canonical virtual address.
-- [ ] Draw four-level x86_64 page translation.
-- [ ] Explain exception versus hardware interrupt.
-- [ ] Inspect CPUID output in a user-space experiment.
-- [ ] Step through a C function prologue and epilogue in GDB.
-
-## Completion signal
-
-You can follow a CPU from kernel entry to a C function and explain where the stack, instruction pointer, page tables and privilege state come from.
-
----
-
-# Foundation C — Toolchain, ELF and linking
-
-## Learn
-
-- preprocessing, compilation, assembly and linking;
-- object files;
-- symbols and relocations;
-- ELF headers, sections and program headers;
-- static versus dynamic linking;
-- linker scripts;
-- load memory address versus virtual memory address;
-- debug information;
-- symbol maps;
-- compiler-generated runtime helpers;
-- why freestanding code can still cause unresolved compiler builtins.
-
-## Exercises
-
-- [ ] Compile one C source to assembly.
-- [ ] Inspect an object with `readelf`, `llvm-readobj` and `objdump`.
-- [ ] Build a minimal ELF with a custom linker script.
-- [ ] Find entry point, sections and load segments.
-- [ ] Trigger and resolve a missing compiler-runtime symbol.
-- [ ] Generate and inspect a link map.
-
-## Completion signal
-
-You can explain exactly how source files become a loadable kernel ELF and how the bootloader finds its entry point.
-
----
-
-# M0 study — Build engineering
-
-## Architecture-neutral topics
-
-- dependency graphs;
-- incremental builds;
-- generated artifacts;
-- hermetic and reproducible builds;
-- build profiles;
-- cross compilation;
-- host tools versus target binaries;
-- dependency version pinning;
-- CI caching and artifact retention.
-
-## Tools
-
-- Meson;
-- Ninja;
-- Clang;
-- LLD;
-- Python only for orchestration tasks that Meson should not own;
-- QEMU;
-- GDB.
-
-## Exercises
-
-- [ ] Build two C translation units incrementally.
-- [ ] Verify automatic header dependencies.
-- [ ] Keep debug and release build directories side by side.
-- [ ] Generate `compile_commands.json`.
-- [ ] Time cold, incremental and no-op builds.
-- [ ] Reproduce the build in a clean container.
-
-## Questions to answer in the video
-
-- Why is deleting the build directory on every compilation inefficient?
-- What does Ninja know that a shell script does not?
-- Which programs run on the host, and which artifacts target the kernel machine?
-
----
-
-# M1 study — Firmware, boot and execution environment
-
-## Architecture-neutral topics
-
-- firmware responsibility;
-- bootloader responsibility;
-- kernel responsibility;
-- boot protocol contracts;
-- normalized boot information;
-- early initialization ordering;
-- stack requirements;
-- controlled halt and failure reporting.
-
-## x86_64 and UEFI topics
-
-- UEFI concept and EFI System Partition;
-- PE/COFF role for EFI applications;
-- Limine loading an ELF64 kernel;
-- long-mode assumptions supplied by the boot protocol;
-- initial memory map;
-- serial communication through legacy COM1 under QEMU.
-
-## Exercises
-
-- [ ] Boot a minimal kernel and stop at its entry symbol in GDB.
-- [ ] Inspect the initial stack pointer alignment.
-- [ ] Print normalized firmware and memory information.
-- [ ] Remove one mandatory boot response and verify controlled failure.
-- [ ] Compare UEFI boot with the conceptual legacy BIOS path.
-
-## Abstraction reflection
-
-Document what would change if the backend used ARM64 with UEFI or RISC-V with SBI/OpenSBI.
-
----
-
-# M2 study — Exceptions, interrupt frames and diagnostics
-
-## Architecture-neutral topics
-
-- synchronous exceptions;
-- asynchronous interrupts;
-- saved execution contexts;
-- reentrancy;
-- fatal versus recoverable faults;
-- panic design;
-- emergency logging;
-- stack unwinding fundamentals.
-
-## x86_64 topics
-
-- IDT gates;
-- exception vectors;
-- error-code exceptions;
-- privilege transitions;
-- TSS and IST;
-- `iretq` frame;
-- page-fault error code;
-- CR2;
-- double faults.
-
-## Exercises
-
-- [ ] Decode a manually constructed exception frame.
-- [ ] Trigger divide-by-zero, invalid opcode and page fault.
-- [ ] Verify the C and assembly context layouts using static assertions.
-- [ ] Generate a stack trace using frame pointers.
-- [ ] Trigger a nested failure and observe the emergency path.
-
-## Abstraction reflection
-
-Separate `exception_info` from the raw x86_64 interrupt frame. Record which fields are universal and which are platform-specific.
-
----
-
-# M3 study — Physical memory management
-
-## Architecture-neutral topics
-
-- physical memory ownership;
-- page frames;
-- firmware memory maps;
-- reserved, reclaimable and device memory;
-- fragmentation;
-- bitmap, free-list and buddy allocation;
-- contiguous allocation;
-- metadata placement;
-- ownership invariants.
-
-## x86_64 topics
-
-- 4 KiB base pages;
-- large-page awareness;
-- memory map supplied through Limine;
-- physical-address width discovery;
-- MMIO regions.
-
-## Exercises
-
-- [ ] Normalize overlapping synthetic memory maps.
-- [ ] Implement and host-test a bitmap allocator.
-- [ ] Allocate all pages and free them in randomized order.
-- [ ] Detect double free and unaligned free.
-- [ ] Compare bitmap and buddy tradeoffs without implementing buddy yet.
-
-## Abstraction reflection
-
-The PMM must know page size and physical limits through platform configuration, not through scattered constants.
-
----
-
-# M4 study — Virtual memory
-
-## Architecture-neutral topics
-
-- address spaces;
-- virtual-to-physical translation;
-- page permissions;
-- user/kernel separation;
-- demand versus eager mapping;
-- copy-on-write concept;
-- direct physical maps;
-- TLBs;
-- address-space switching;
-- guard pages;
-- executable versus writable memory.
-
-## x86_64 topics
-
-- PML4, PDPT, PD and PT;
-- canonical addresses;
-- page-table entry flags;
-- CR3;
-- NXE and NX;
-- `invlpg`;
-- PCID as a deferred optimization;
-- higher-half kernel design.
-
-## Exercises
-
-- [ ] Walk a virtual address by hand.
-- [ ] Implement map, resolve and unmap tests.
-- [ ] Test mappings across every table boundary.
-- [ ] Produce read-only and NX faults.
-- [ ] Destroy an address space and verify frame reclamation.
-- [ ] Add a guard page below a stack.
-
-## Abstraction reflection
-
-Generic VM flags should not reuse hardware bit positions. A backend must translate them.
-
----
-
-# M5 study — Dynamic allocation
-
-## Architecture-neutral topics
-
-- allocation semantics;
-- alignment;
-- fragmentation;
-- metadata corruption;
-- free lists;
-- boundary tags;
-- splitting and coalescing;
-- slab and object caches;
-- allocation context restrictions;
-- debug poisoning and canaries.
-
-## Exercises
-
-- [ ] Write a bump allocator.
-- [ ] Write and host-test an aligned free-list allocator.
-- [ ] Fuzz allocation/free sequences.
-- [ ] Measure fragmentation.
-- [ ] Compare free-list, buddy and slab use cases.
-- [ ] Verify integer-overflow handling in size calculations.
-
-## Abstraction reflection
-
-Keep heap policy separate from the VM mechanism that supplies pages.
-
----
-
-# M6 study — Hardware discovery, interrupts and clocks
-
-## Architecture-neutral topics
-
-- hardware-description tables;
-- interrupt controllers;
-- interrupt routing;
-- masking and acknowledgement;
-- edge versus level triggering;
-- clock sources;
-- clock events;
-- monotonic time;
-- calibration;
-- timer deadlines versus periodic ticks.
-
-## x86_64 topics
-
-- ACPI RSDP, XSDT and checksums;
-- MADT;
-- Local APIC;
-- IOAPIC;
-- legacy PIC;
-- LAPIC timer;
-- HPET and TSC concepts;
-- spurious interrupt vector.
-
-## Exercises
-
-- [ ] Parse synthetic ACPI tables with invalid lengths and checksums.
-- [ ] Draw interrupt routing from device to kernel handler.
-- [ ] Receive and acknowledge a timer interrupt.
-- [ ] Mask and unmask an interrupt source.
-- [ ] Compare clock source and clock event device.
-
-## Abstraction reflection
-
-Use controller and clock interfaces rather than naming APIC inside scheduler or generic time code.
-
----
-
-# M7 study — Concurrency and scheduling
-
-## Architecture-neutral topics
-
-- execution context;
-- kernel thread;
-- process versus thread;
-- cooperative and preemptive scheduling;
-- scheduling policies;
-- ready, blocked and terminated states;
-- race conditions;
-- critical sections;
-- interrupt disabling versus locks;
-- wait queues;
-- lifetime and reclamation.
-
-## x86_64 topics
-
-- context-switch register set;
-- stack switching;
-- ABI-preserved registers;
-- interrupt return into a selected context;
-- per-CPU concepts, even though SMP is deferred.
-
-## Exercises
-
-- [ ] Implement a host-side scheduler queue model.
-- [ ] Construct a new kernel-thread stack manually.
-- [ ] Switch cooperatively between two threads.
-- [ ] Add timer preemption.
-- [ ] Block and wake a thread.
-- [ ] Verify register preservation with known patterns.
-
-## Abstraction reflection
-
-The scheduler chooses a thread; architecture code performs the low-level context switch.
-
----
-
-# M8 study — Protection and user mode
-
-## Architecture-neutral topics
-
-- protection domains;
-- processes;
-- privilege separation;
-- kernel and user address ranges;
-- fault containment;
-- safe memory copying;
-- time-of-check/time-of-use issues;
-- process lifecycle.
-
-## x86_64 topics
-
-- Ring 0 and Ring 3;
-- segment selectors in long mode;
-- TSS `RSP0`;
-- user/supervisor page bit;
-- `iretq` transition;
-- SMAP/SMEP as later hardening features.
-
-## Exercises
-
-- [ ] Enter a user function.
-- [ ] Read the current privilege level.
-- [ ] Attempt a privileged instruction from user mode.
-- [ ] Attempt to modify a kernel page.
-- [ ] Safely terminate only the faulty process.
-- [ ] Test invalid ranges passed to copy helpers.
-
-## Abstraction reflection
-
-Model privilege as kernel/user execution domains rather than exposing x86 ring numbers to generic process code.
-
----
-
-# M9 study — System calls and ABI design
-
-## Architecture-neutral topics
-
-- syscall purpose;
-- ABI stability;
-- argument passing;
-- error conventions;
-- capability and permission checks;
-- pointer validation;
-- blocking syscalls;
-- restart semantics;
-- versioning.
-
-## x86_64 topics
-
-- `syscall/sysret` registers and MSRs;
-- `iretq` fallback path;
-- `swapgs` concept for future per-CPU state;
-- canonical return-address validation;
-- calling-convention differences between user ABI and syscall ABI.
-
-## Exercises
-
-- [ ] Write an ABI table for three syscalls.
-- [ ] Implement unknown-syscall handling.
-- [ ] Test bad pointers and extreme lengths.
-- [ ] Verify clobbered and preserved registers.
-- [ ] Trace a syscall from user stub to kernel and back.
-
-## Abstraction reflection
-
-The syscall semantic layer should not depend on the machine entry instruction.
-
----
-
-# M10 study — Archives, executable formats and process images
-
-## Architecture-neutral topics
-
-- byte-stream validation;
-- archive formats;
-- executable formats;
-- segments versus sections;
-- loader security;
-- integer overflow during parsing;
-- process image construction;
-- initial stack and argument conventions.
-
-## x86_64 topics
-
-- ELF64;
-- x86_64 machine identifier;
-- little-endian encoding;
-- loadable segments;
-- executable entry point;
-- static user binaries.
-
-## Exercises
-
-- [ ] Parse ELF64 host-side using only bounds-checked reads.
-- [ ] Reject malformed headers and overflowing offsets.
-- [ ] Map segments with correct permissions.
-- [ ] Zero BSS.
-- [ ] Build a tiny freestanding user program.
-- [ ] Load and run it from initramfs.
-
-## Abstraction reflection
-
-Keep the generic executable loader separate from the architecture-specific validation and initial CPU-context creation.
-
----
-
-# M11 study — Filesystems and VFS
-
-## Architecture-neutral topics
-
-- namespace;
-- path resolution;
-- files, directories and devices;
-- inode/vnode concepts;
-- mounts;
-- file handles and descriptors;
-- offsets;
-- filesystem operations;
-- caching and lifetime basics;
-- permissions as a later extension.
-
-## Exercises
-
-- [ ] Build a host-side in-memory VFS prototype.
-- [ ] Parse absolute paths safely.
-- [ ] Handle `.`, `..` and repeated separators.
-- [ ] Mount an initramfs root.
-- [ ] Implement independent file offsets.
-- [ ] Add a console device.
-
-## Abstraction reflection
-
-VFS clients must not know whether a file comes from TAR, FAT, ext2 or a device driver.
-
----
-
-# Deferred study tracks
-
-Study these only when the initial user-space cycle is stable.
-
-## Synchronization and SMP
-
-- atomic operations;
-- memory models;
-- spinlocks;
-- mutexes;
-- reader/writer locks;
-- per-CPU data;
-- inter-processor interrupts;
-- TLB shootdowns;
-- lock ordering;
-- deadlock detection.
-
-## Devices and buses
-
-- PCI/PCIe configuration;
-- MMIO;
+# Fondamenta B — Architettura dei calcolatori
+
+## Concetti generali
+
+- livelli di privilegio;
+- esecuzione delle istruzioni e basi della pipeline;
+- registri e stato del processore;
+- interrupt ed eccezioni;
+- indirizzi virtuali e fisici;
+- cache e gerarchia di memoria;
+- ordinamento della memoria;
+- MMIO e port I/O;
 - DMA;
-- MSI/MSI-X;
-- block-device abstraction;
-- AHCI or NVMe;
-- USB architecture.
+- basi del multiprocessore;
+- firmware e descrizione dell’hardware.
 
-## Persistent filesystems
+## Focus x86_64
 
-- block cache;
-- FAT or ext2;
-- consistency;
-- allocation maps;
-- directory structures;
-- crash behavior.
+- registri generali, `RIP`, `RSP`, `RFLAGS`;
+- long mode e indirizzi canonici;
+- control register e MSR;
+- GDT, TSS e IDT;
+- gerarchia del paging;
+- CPUID;
+- famiglia APIC;
+- `syscall/sysret` e `iretq`;
+- System V AMD64 ABI come riferimento, non come ABI kernel imposta.
+
+## Esercizi
+
+- [ ] leggere e annotare un dump dei registri;
+- [ ] decodificare un indirizzo canonico;
+- [ ] disegnare la traduzione a quattro livelli;
+- [ ] distinguere eccezione e interrupt hardware;
+- [ ] ispezionare CPUID da user space;
+- [ ] seguire prologo ed epilogo di una funzione in GDB.
+
+---
+
+# Fondamenta C — Toolchain, ELF e linking
+
+## Studiare
+
+- preprocessing, compilazione, assembly e link;
+- object file;
+- simboli e rilocazioni;
+- header, sezioni e program header ELF;
+- link statico e dinamico;
+- linker script;
+- indirizzo di caricamento e indirizzo virtuale;
+- informazioni di debug e map file;
+- helper runtime generati dal compilatore.
+
+## Esercizi
+
+- [ ] compilare C in assembly;
+- [ ] ispezionare oggetti con `readelf`, `llvm-readobj`, `objdump`;
+- [ ] costruire un ELF minimo con linker script;
+- [ ] individuare entry, sezioni e segmenti;
+- [ ] provocare e risolvere un simbolo runtime mancante;
+- [ ] generare e leggere una link map.
+
+---
+
+# Studio M0 — Ingegneria della build
+
+## Concetti
+
+Grafi delle dipendenze, build incrementali, artefatti generati, riproducibilità, profili, cross-compilazione, strumenti host e binari target, version pinning, cache CI.
+
+## Strumenti
+
+Meson, Ninja, Clang, LLD, Python solo per orchestrazione, QEMU e GDB.
+
+## Esercizi
+
+- [ ] compilare incrementalmente due translation unit;
+- [ ] verificare dipendenze automatiche dagli header;
+- [ ] mantenere debug e release affiancate;
+- [ ] generare `compile_commands.json`;
+- [ ] misurare build cold, incrementale e no-op;
+- [ ] riprodurre tutto in un container pulito.
+
+Domande da spiegare: perché cancellare la directory di build è inefficiente? Cosa conosce Ninja che uno script shell non conosce? Quali programmi girano sull’host e quali artefatti sono per il target?
+
+---
+
+# Studio M1 — Firmware, boot e ambiente di esecuzione
+
+## Concetti generali
+
+Responsabilità di firmware, bootloader e kernel; contratto di boot; normalizzazione delle informazioni; ordine dell’early init; requisiti dello stack; halt controllato.
+
+## Focus x86_64/UEFI
+
+UEFI ed EFI System Partition, ruolo PE/COFF, Limine e kernel ELF64, assunzioni del long mode, memory map iniziale, seriale COM1 in QEMU.
+
+## Esercizi
+
+- [ ] fermarsi all’entry point con GDB;
+- [ ] verificare l’allineamento iniziale dello stack;
+- [ ] stampare firmware e memoria normalizzati;
+- [ ] rimuovere una risposta obbligatoria e verificare l’errore controllato;
+- [ ] confrontare concettualmente UEFI e BIOS legacy.
+
+Riflessione: cosa cambierebbe con ARM64/UEFI o RISC-V/SBI?
+
+---
+
+# Studio M2 — Eccezioni, interrupt frame e diagnostica
+
+## Concetti generali
+
+Eccezioni sincrone, interrupt asincroni, contesti salvati, rientranza, fault recuperabili e fatali, panic, logging di emergenza, stack unwinding.
+
+## Focus x86_64
+
+Gate IDT, vettori, eccezioni con error code, transizioni di privilegio, TSS e IST, frame `iretq`, page-fault code, CR2 e double fault.
+
+## Esercizi
+
+- [ ] decodificare un frame costruito manualmente;
+- [ ] provocare divide-by-zero, invalid opcode e page fault;
+- [ ] verificare layout C/assembly con `static_assert`;
+- [ ] produrre uno stack trace con frame pointer;
+- [ ] testare un fallimento annidato.
+
+---
+
+# Studio M3 — Memoria fisica
+
+## Concetti
+
+Proprietà della memoria, frame, memory map firmware, regioni riservate o reclamabili, frammentazione, bitmap/free-list/buddy, allocazione contigua, metadati e invarianti.
+
+## Focus x86_64
+
+Pagine da 4 KiB, consapevolezza delle large page, map Limine, larghezza dell’indirizzo fisico e MMIO.
+
+## Esercizi
+
+- [ ] normalizzare mappe sintetiche sovrapposte;
+- [ ] implementare e testare un allocator bitmap;
+- [ ] allocare tutte le pagine e liberarle in ordine casuale;
+- [ ] rilevare double-free e free non allineato;
+- [ ] confrontare bitmap e buddy senza implementare subito buddy.
+
+---
+
+# Studio M4 — Memoria virtuale
+
+## Concetti
+
+Address space, traduzione, permessi, separazione kernel/utente, mapping eager e demand, copy-on-write come concetto, direct map, TLB, cambio address space, guard page, W^X.
+
+## Focus x86_64
+
+PML4/PDPT/PD/PT, indirizzi canonici, flag delle entry, CR3, NXE/NX, `invlpg`, PCID rimandato e kernel high-half.
+
+## Esercizi
+
+- [ ] attraversare manualmente un indirizzo virtuale;
+- [ ] implementare test map/resolve/unmap;
+- [ ] testare ogni confine delle tabelle;
+- [ ] provocare fault read-only e NX;
+- [ ] distruggere un address space verificando il rilascio dei frame;
+- [ ] aggiungere una guard page sotto uno stack.
+
+---
+
+# Studio M5 — Allocazione dinamica
+
+## Concetti
+
+Semantica di allocazione, allineamento, frammentazione, corruzione dei metadati, free list, boundary tag, splitting, coalescing, slab, contesti di allocazione, poisoning e canary.
+
+## Esercizi
+
+- [ ] bump allocator;
+- [ ] free-list allineata testata sull’host;
+- [ ] fuzz di sequenze alloc/free;
+- [ ] misura della frammentazione;
+- [ ] confronto tra free-list, buddy e slab;
+- [ ] verifica degli overflow nei calcoli delle dimensioni.
+
+---
+
+# Studio M6 — Scoperta hardware, interrupt e clock
+
+## Concetti
+
+Tabelle di descrizione, controller interrupt, routing, masking, acknowledgement, edge/level trigger, clock source, clock event, tempo monotono, calibrazione, deadline e tick periodico.
+
+## Focus x86_64
+
+ACPI RSDP/XSDT e checksum, MADT, LAPIC, IOAPIC, PIC legacy, timer LAPIC, HPET e TSC, vettore spurio.
+
+## Esercizi
+
+- [ ] analizzare tabelle ACPI sintetiche malformate;
+- [ ] disegnare il percorso device→handler;
+- [ ] ricevere e riconoscere un timer interrupt;
+- [ ] mask/unmask di una sorgente;
+- [ ] distinguere clock source e clock event.
+
+---
+
+# Studio M7 — Concorrenza e scheduling
+
+## Concetti
+
+Contesto di esecuzione, thread e processo, scheduling cooperativo/preemptive, stati, race, sezioni critiche, interrupt disabling e lock, wait queue, lifetime e reclamazione.
+
+## Focus x86_64
+
+Set di registri del context switch, cambio stack, registri preservati dall’ABI, ritorno da interrupt, concetti per-CPU pur rimandando SMP.
+
+## Esercizi
+
+- [ ] modello host-side della ready queue;
+- [ ] costruzione manuale dello stack di un nuovo thread;
+- [ ] switch cooperativo tra due thread;
+- [ ] preemption da timer;
+- [ ] block/wake;
+- [ ] verifica dei registri con pattern noti.
+
+---
+
+# Studio M8 — Protezione e modalità utente
+
+## Concetti
+
+Domini di protezione, processi, separazione dei privilegi, range kernel/utente, contenimento dei fault, copie sicure, TOCTOU e ciclo di vita.
+
+## Focus x86_64
+
+Ring 0/Ring 3, selector in long mode, `RSP0`, bit user/supervisor, `iretq`, SMEP/SMAP come hardening futuro.
+
+## Esercizi
+
+- [ ] entrare in una funzione utente;
+- [ ] verificare il livello di privilegio;
+- [ ] tentare un’istruzione privilegiata;
+- [ ] tentare di modificare una pagina kernel;
+- [ ] terminare solo il processo colpevole;
+- [ ] testare range invalidi nei copy helper.
+
+---
+
+# Studio M9 — Syscall e design ABI
+
+## Concetti
+
+Scopo delle syscall, stabilità ABI, passaggio argomenti, convenzioni degli errori, permessi, puntatori utente, syscall bloccanti, restart e versioning.
+
+## Focus x86_64
+
+Registri e MSR di `syscall/sysret`, fallback `iretq`, concetto di `swapgs`, validazione dell’indirizzo di ritorno, differenza tra ABI utente e ABI syscall.
+
+## Esercizi
+
+- [ ] tabella ABI per tre syscall;
+- [ ] syscall sconosciuta;
+- [ ] puntatori errati e lunghezze estreme;
+- [ ] registri clobbered e preservati;
+- [ ] tracing completo user→kernel→user.
+
+---
+
+# Studio M10 — Archivi, ELF e immagini di processo
+
+## Concetti
+
+Validazione di byte stream, archivi, formati eseguibili, segmenti e sezioni, sicurezza del loader, overflow nel parsing, immagine del processo e stack iniziale.
+
+## Focus x86_64
+
+ELF64, machine identifier x86_64, little endian, segmenti loadable, entry point e binari statici.
+
+## Esercizi
+
+- [ ] parser ELF64 host-side con letture bounds-checked;
+- [ ] rifiuto di header malformati e offset in overflow;
+- [ ] mapping con permessi corretti;
+- [ ] azzeramento BSS;
+- [ ] piccolo programma freestanding utente;
+- [ ] caricamento ed esecuzione da initramfs.
+
+---
+
+# Studio M11 — Filesystem e VFS
+
+## Concetti
+
+Namespace, path resolution, file, directory e device, inode/vnode, mount, file handle e descriptor, offset, operazioni del filesystem, lifetime e caching di base.
+
+## Esercizi
+
+- [ ] prototipo VFS in memoria sull’host;
+- [ ] parser sicuro dei percorsi assoluti;
+- [ ] gestione di `.`, `..` e separatori ripetuti;
+- [ ] mount root dell’initramfs;
+- [ ] offset indipendenti;
+- [ ] device console.
+
+---
+
+# Percorsi rimandati
+
+## Sincronizzazione e SMP
+
+Atomici, memory model, spinlock, mutex, reader/writer lock, dati per-CPU, IPI, TLB shootdown, ordine dei lock e deadlock.
+
+## Device e bus
+
+PCI/PCIe, MMIO, DMA, MSI/MSI-X, block device, AHCI/NVMe e USB.
+
+## Filesystem persistenti
+
+Block cache, FAT/ext2, consistenza, bitmap di allocazione, directory e comportamento dopo crash.
 
 ## Networking
 
-- NIC drivers;
-- Ethernet;
-- ARP;
-- IPv4/IPv6;
-- routing;
-- UDP and TCP;
-- socket abstraction.
+Driver NIC, Ethernet, ARP, IPv4/IPv6, routing, UDP/TCP e socket.
 
-## Second architecture validation
+## Seconda architettura
 
-After the generic contracts are stable, use a small second backend to test them. ARM64 or RISC-V are candidates, but the purpose is to validate abstractions, not to promise immediate feature parity.
+Dopo la stabilizzazione dei contratti generici, un backend minimo ARM64 o RISC-V dovrà validarli senza promettere parità immediata di funzionalità.
 
 ---
 
-# Recommended primary references
+# Riferimenti primari consigliati
 
-Prefer primary sources and specifications over tutorial copying:
+Preferire specifiche e documentazione primaria:
 
-- ISO C language material and compiler documentation;
+- materiale ISO C e documentazione dei compilatori;
 - System V AMD64 ABI;
-- Intel or AMD architecture manuals;
-- UEFI specification;
-- Limine protocol documentation;
-- ELF specification;
-- ACPI specification;
-- Meson and Ninja documentation;
-- QEMU and GDB manuals.
+- manuali Intel o AMD;
+- specifica UEFI;
+- documentazione del protocollo Limine;
+- specifica ELF;
+- specifica ACPI;
+- documentazione Meson e Ninja;
+- manuali QEMU e GDB.
 
-Secondary resources are useful for intuition, but each hardware-sensitive implementation should ultimately be checked against an authoritative specification.
+Le risorse secondarie sono utili per l’intuizione, ma ogni implementazione sensibile all’hardware deve essere verificata contro una fonte autorevole.

--- a/docs/new-project/STUDY_PLAN.md
+++ b/docs/new-project/STUDY_PLAN.md
@@ -1,0 +1,660 @@
+# OS Development Study Plan
+
+This study plan follows the project milestones. It is not a prerequisite wall: study and implementation should alternate. Each topic should be learned deeply enough to explain it, implement a minimal version and debug common failures.
+
+The implementation begins on **x86_64 in 64-bit mode**, while the study plan separates universal operating-system concepts from x86_64-specific mechanisms.
+
+## Study method for every milestone
+
+For each subject:
+
+1. learn the architecture-neutral concept;
+2. identify the contract the kernel needs;
+3. study the x86_64 mechanism used for the first backend;
+4. implement the smallest observable version;
+5. create success and failure tests;
+6. explain the result without hiding bootloader or hardware assumptions;
+7. write down what would change on another architecture.
+
+Each learning unit should produce:
+
+- [ ] concise personal notes;
+- [ ] a diagram;
+- [ ] a glossary;
+- [ ] one minimal experiment;
+- [ ] one failure experiment;
+- [ ] one YouTube episode outline;
+- [ ] references to primary documentation.
+
+---
+
+# Foundation A — Modern freestanding C23
+
+## Learn
+
+- translation units;
+- declarations and definitions;
+- object lifetime and storage duration;
+- integer conversion and promotion rules;
+- pointer arithmetic;
+- alignment and padding;
+- strict aliasing and effective types;
+- undefined, unspecified and implementation-defined behavior;
+- volatile semantics and its limitations;
+- atomics at a conceptual level;
+- freestanding versus hosted implementations;
+- compiler builtins and extensions;
+- calling conventions and ABI boundaries.
+
+## C23 features to use deliberately
+
+- `static_assert`;
+- standard attributes such as `[[noreturn]]`, `[[nodiscard]]` and `[[maybe_unused]]`;
+- fixed-underlying-type enums where compiler support is verified;
+- `nullptr` where supported by the selected compiler baseline;
+- binary literals where they improve bit-field explanations;
+- checked and explicit integer operations.
+
+## Exercises
+
+- [ ] Inspect structure layout with `sizeof`, `alignof` and `offsetof`.
+- [ ] Write overflow-safe alignment helpers.
+- [ ] Implement `memset`, `memcpy`, `memmove`, `memcmp` and `strlen`.
+- [ ] Test overlapping memory moves.
+- [ ] Demonstrate why signed overflow is not a wrapping operation.
+- [ ] Compare generated assembly for `volatile` and non-volatile accesses.
+- [ ] Create a compiler abstraction header for attributes and barriers.
+
+## Completion signal
+
+You can explain why code that looks correct in C may still be invalid for a kernel because of undefined behavior, ABI assumptions or optimizer transformations.
+
+---
+
+# Foundation B — Computer architecture
+
+## Architecture-neutral topics
+
+- privilege levels;
+- instruction execution and pipeline basics;
+- registers and processor state;
+- interrupts and exceptions;
+- virtual and physical addresses;
+- caches and memory hierarchy;
+- memory ordering;
+- MMIO versus port IO;
+- DMA concept;
+- multiprocessor basics;
+- firmware and hardware-description mechanisms.
+
+## x86_64 focus
+
+- general-purpose registers;
+- `RIP`, `RSP`, `RFLAGS`;
+- long mode;
+- canonical addresses;
+- control registers;
+- model-specific registers;
+- GDT, TSS and IDT;
+- paging hierarchy;
+- CPUID;
+- APIC family;
+- `syscall/sysret` and `iretq`;
+- System V AMD64 calling convention as a reference, not an unquestioned kernel ABI.
+
+## Exercises
+
+- [ ] Read and annotate a register dump.
+- [ ] Decode a canonical virtual address.
+- [ ] Draw four-level x86_64 page translation.
+- [ ] Explain exception versus hardware interrupt.
+- [ ] Inspect CPUID output in a user-space experiment.
+- [ ] Step through a C function prologue and epilogue in GDB.
+
+## Completion signal
+
+You can follow a CPU from kernel entry to a C function and explain where the stack, instruction pointer, page tables and privilege state come from.
+
+---
+
+# Foundation C — Toolchain, ELF and linking
+
+## Learn
+
+- preprocessing, compilation, assembly and linking;
+- object files;
+- symbols and relocations;
+- ELF headers, sections and program headers;
+- static versus dynamic linking;
+- linker scripts;
+- load memory address versus virtual memory address;
+- debug information;
+- symbol maps;
+- compiler-generated runtime helpers;
+- why freestanding code can still cause unresolved compiler builtins.
+
+## Exercises
+
+- [ ] Compile one C source to assembly.
+- [ ] Inspect an object with `readelf`, `llvm-readobj` and `objdump`.
+- [ ] Build a minimal ELF with a custom linker script.
+- [ ] Find entry point, sections and load segments.
+- [ ] Trigger and resolve a missing compiler-runtime symbol.
+- [ ] Generate and inspect a link map.
+
+## Completion signal
+
+You can explain exactly how source files become a loadable kernel ELF and how the bootloader finds its entry point.
+
+---
+
+# M0 study — Build engineering
+
+## Architecture-neutral topics
+
+- dependency graphs;
+- incremental builds;
+- generated artifacts;
+- hermetic and reproducible builds;
+- build profiles;
+- cross compilation;
+- host tools versus target binaries;
+- dependency version pinning;
+- CI caching and artifact retention.
+
+## Tools
+
+- Meson;
+- Ninja;
+- Clang;
+- LLD;
+- Python only for orchestration tasks that Meson should not own;
+- QEMU;
+- GDB.
+
+## Exercises
+
+- [ ] Build two C translation units incrementally.
+- [ ] Verify automatic header dependencies.
+- [ ] Keep debug and release build directories side by side.
+- [ ] Generate `compile_commands.json`.
+- [ ] Time cold, incremental and no-op builds.
+- [ ] Reproduce the build in a clean container.
+
+## Questions to answer in the video
+
+- Why is deleting the build directory on every compilation inefficient?
+- What does Ninja know that a shell script does not?
+- Which programs run on the host, and which artifacts target the kernel machine?
+
+---
+
+# M1 study — Firmware, boot and execution environment
+
+## Architecture-neutral topics
+
+- firmware responsibility;
+- bootloader responsibility;
+- kernel responsibility;
+- boot protocol contracts;
+- normalized boot information;
+- early initialization ordering;
+- stack requirements;
+- controlled halt and failure reporting.
+
+## x86_64 and UEFI topics
+
+- UEFI concept and EFI System Partition;
+- PE/COFF role for EFI applications;
+- Limine loading an ELF64 kernel;
+- long-mode assumptions supplied by the boot protocol;
+- initial memory map;
+- serial communication through legacy COM1 under QEMU.
+
+## Exercises
+
+- [ ] Boot a minimal kernel and stop at its entry symbol in GDB.
+- [ ] Inspect the initial stack pointer alignment.
+- [ ] Print normalized firmware and memory information.
+- [ ] Remove one mandatory boot response and verify controlled failure.
+- [ ] Compare UEFI boot with the conceptual legacy BIOS path.
+
+## Abstraction reflection
+
+Document what would change if the backend used ARM64 with UEFI or RISC-V with SBI/OpenSBI.
+
+---
+
+# M2 study — Exceptions, interrupt frames and diagnostics
+
+## Architecture-neutral topics
+
+- synchronous exceptions;
+- asynchronous interrupts;
+- saved execution contexts;
+- reentrancy;
+- fatal versus recoverable faults;
+- panic design;
+- emergency logging;
+- stack unwinding fundamentals.
+
+## x86_64 topics
+
+- IDT gates;
+- exception vectors;
+- error-code exceptions;
+- privilege transitions;
+- TSS and IST;
+- `iretq` frame;
+- page-fault error code;
+- CR2;
+- double faults.
+
+## Exercises
+
+- [ ] Decode a manually constructed exception frame.
+- [ ] Trigger divide-by-zero, invalid opcode and page fault.
+- [ ] Verify the C and assembly context layouts using static assertions.
+- [ ] Generate a stack trace using frame pointers.
+- [ ] Trigger a nested failure and observe the emergency path.
+
+## Abstraction reflection
+
+Separate `exception_info` from the raw x86_64 interrupt frame. Record which fields are universal and which are platform-specific.
+
+---
+
+# M3 study — Physical memory management
+
+## Architecture-neutral topics
+
+- physical memory ownership;
+- page frames;
+- firmware memory maps;
+- reserved, reclaimable and device memory;
+- fragmentation;
+- bitmap, free-list and buddy allocation;
+- contiguous allocation;
+- metadata placement;
+- ownership invariants.
+
+## x86_64 topics
+
+- 4 KiB base pages;
+- large-page awareness;
+- memory map supplied through Limine;
+- physical-address width discovery;
+- MMIO regions.
+
+## Exercises
+
+- [ ] Normalize overlapping synthetic memory maps.
+- [ ] Implement and host-test a bitmap allocator.
+- [ ] Allocate all pages and free them in randomized order.
+- [ ] Detect double free and unaligned free.
+- [ ] Compare bitmap and buddy tradeoffs without implementing buddy yet.
+
+## Abstraction reflection
+
+The PMM must know page size and physical limits through platform configuration, not through scattered constants.
+
+---
+
+# M4 study — Virtual memory
+
+## Architecture-neutral topics
+
+- address spaces;
+- virtual-to-physical translation;
+- page permissions;
+- user/kernel separation;
+- demand versus eager mapping;
+- copy-on-write concept;
+- direct physical maps;
+- TLBs;
+- address-space switching;
+- guard pages;
+- executable versus writable memory.
+
+## x86_64 topics
+
+- PML4, PDPT, PD and PT;
+- canonical addresses;
+- page-table entry flags;
+- CR3;
+- NXE and NX;
+- `invlpg`;
+- PCID as a deferred optimization;
+- higher-half kernel design.
+
+## Exercises
+
+- [ ] Walk a virtual address by hand.
+- [ ] Implement map, resolve and unmap tests.
+- [ ] Test mappings across every table boundary.
+- [ ] Produce read-only and NX faults.
+- [ ] Destroy an address space and verify frame reclamation.
+- [ ] Add a guard page below a stack.
+
+## Abstraction reflection
+
+Generic VM flags should not reuse hardware bit positions. A backend must translate them.
+
+---
+
+# M5 study — Dynamic allocation
+
+## Architecture-neutral topics
+
+- allocation semantics;
+- alignment;
+- fragmentation;
+- metadata corruption;
+- free lists;
+- boundary tags;
+- splitting and coalescing;
+- slab and object caches;
+- allocation context restrictions;
+- debug poisoning and canaries.
+
+## Exercises
+
+- [ ] Write a bump allocator.
+- [ ] Write and host-test an aligned free-list allocator.
+- [ ] Fuzz allocation/free sequences.
+- [ ] Measure fragmentation.
+- [ ] Compare free-list, buddy and slab use cases.
+- [ ] Verify integer-overflow handling in size calculations.
+
+## Abstraction reflection
+
+Keep heap policy separate from the VM mechanism that supplies pages.
+
+---
+
+# M6 study — Hardware discovery, interrupts and clocks
+
+## Architecture-neutral topics
+
+- hardware-description tables;
+- interrupt controllers;
+- interrupt routing;
+- masking and acknowledgement;
+- edge versus level triggering;
+- clock sources;
+- clock events;
+- monotonic time;
+- calibration;
+- timer deadlines versus periodic ticks.
+
+## x86_64 topics
+
+- ACPI RSDP, XSDT and checksums;
+- MADT;
+- Local APIC;
+- IOAPIC;
+- legacy PIC;
+- LAPIC timer;
+- HPET and TSC concepts;
+- spurious interrupt vector.
+
+## Exercises
+
+- [ ] Parse synthetic ACPI tables with invalid lengths and checksums.
+- [ ] Draw interrupt routing from device to kernel handler.
+- [ ] Receive and acknowledge a timer interrupt.
+- [ ] Mask and unmask an interrupt source.
+- [ ] Compare clock source and clock event device.
+
+## Abstraction reflection
+
+Use controller and clock interfaces rather than naming APIC inside scheduler or generic time code.
+
+---
+
+# M7 study — Concurrency and scheduling
+
+## Architecture-neutral topics
+
+- execution context;
+- kernel thread;
+- process versus thread;
+- cooperative and preemptive scheduling;
+- scheduling policies;
+- ready, blocked and terminated states;
+- race conditions;
+- critical sections;
+- interrupt disabling versus locks;
+- wait queues;
+- lifetime and reclamation.
+
+## x86_64 topics
+
+- context-switch register set;
+- stack switching;
+- ABI-preserved registers;
+- interrupt return into a selected context;
+- per-CPU concepts, even though SMP is deferred.
+
+## Exercises
+
+- [ ] Implement a host-side scheduler queue model.
+- [ ] Construct a new kernel-thread stack manually.
+- [ ] Switch cooperatively between two threads.
+- [ ] Add timer preemption.
+- [ ] Block and wake a thread.
+- [ ] Verify register preservation with known patterns.
+
+## Abstraction reflection
+
+The scheduler chooses a thread; architecture code performs the low-level context switch.
+
+---
+
+# M8 study — Protection and user mode
+
+## Architecture-neutral topics
+
+- protection domains;
+- processes;
+- privilege separation;
+- kernel and user address ranges;
+- fault containment;
+- safe memory copying;
+- time-of-check/time-of-use issues;
+- process lifecycle.
+
+## x86_64 topics
+
+- Ring 0 and Ring 3;
+- segment selectors in long mode;
+- TSS `RSP0`;
+- user/supervisor page bit;
+- `iretq` transition;
+- SMAP/SMEP as later hardening features.
+
+## Exercises
+
+- [ ] Enter a user function.
+- [ ] Read the current privilege level.
+- [ ] Attempt a privileged instruction from user mode.
+- [ ] Attempt to modify a kernel page.
+- [ ] Safely terminate only the faulty process.
+- [ ] Test invalid ranges passed to copy helpers.
+
+## Abstraction reflection
+
+Model privilege as kernel/user execution domains rather than exposing x86 ring numbers to generic process code.
+
+---
+
+# M9 study — System calls and ABI design
+
+## Architecture-neutral topics
+
+- syscall purpose;
+- ABI stability;
+- argument passing;
+- error conventions;
+- capability and permission checks;
+- pointer validation;
+- blocking syscalls;
+- restart semantics;
+- versioning.
+
+## x86_64 topics
+
+- `syscall/sysret` registers and MSRs;
+- `iretq` fallback path;
+- `swapgs` concept for future per-CPU state;
+- canonical return-address validation;
+- calling-convention differences between user ABI and syscall ABI.
+
+## Exercises
+
+- [ ] Write an ABI table for three syscalls.
+- [ ] Implement unknown-syscall handling.
+- [ ] Test bad pointers and extreme lengths.
+- [ ] Verify clobbered and preserved registers.
+- [ ] Trace a syscall from user stub to kernel and back.
+
+## Abstraction reflection
+
+The syscall semantic layer should not depend on the machine entry instruction.
+
+---
+
+# M10 study — Archives, executable formats and process images
+
+## Architecture-neutral topics
+
+- byte-stream validation;
+- archive formats;
+- executable formats;
+- segments versus sections;
+- loader security;
+- integer overflow during parsing;
+- process image construction;
+- initial stack and argument conventions.
+
+## x86_64 topics
+
+- ELF64;
+- x86_64 machine identifier;
+- little-endian encoding;
+- loadable segments;
+- executable entry point;
+- static user binaries.
+
+## Exercises
+
+- [ ] Parse ELF64 host-side using only bounds-checked reads.
+- [ ] Reject malformed headers and overflowing offsets.
+- [ ] Map segments with correct permissions.
+- [ ] Zero BSS.
+- [ ] Build a tiny freestanding user program.
+- [ ] Load and run it from initramfs.
+
+## Abstraction reflection
+
+Keep the generic executable loader separate from the architecture-specific validation and initial CPU-context creation.
+
+---
+
+# M11 study — Filesystems and VFS
+
+## Architecture-neutral topics
+
+- namespace;
+- path resolution;
+- files, directories and devices;
+- inode/vnode concepts;
+- mounts;
+- file handles and descriptors;
+- offsets;
+- filesystem operations;
+- caching and lifetime basics;
+- permissions as a later extension.
+
+## Exercises
+
+- [ ] Build a host-side in-memory VFS prototype.
+- [ ] Parse absolute paths safely.
+- [ ] Handle `.`, `..` and repeated separators.
+- [ ] Mount an initramfs root.
+- [ ] Implement independent file offsets.
+- [ ] Add a console device.
+
+## Abstraction reflection
+
+VFS clients must not know whether a file comes from TAR, FAT, ext2 or a device driver.
+
+---
+
+# Deferred study tracks
+
+Study these only when the initial user-space cycle is stable.
+
+## Synchronization and SMP
+
+- atomic operations;
+- memory models;
+- spinlocks;
+- mutexes;
+- reader/writer locks;
+- per-CPU data;
+- inter-processor interrupts;
+- TLB shootdowns;
+- lock ordering;
+- deadlock detection.
+
+## Devices and buses
+
+- PCI/PCIe configuration;
+- MMIO;
+- DMA;
+- MSI/MSI-X;
+- block-device abstraction;
+- AHCI or NVMe;
+- USB architecture.
+
+## Persistent filesystems
+
+- block cache;
+- FAT or ext2;
+- consistency;
+- allocation maps;
+- directory structures;
+- crash behavior.
+
+## Networking
+
+- NIC drivers;
+- Ethernet;
+- ARP;
+- IPv4/IPv6;
+- routing;
+- UDP and TCP;
+- socket abstraction.
+
+## Second architecture validation
+
+After the generic contracts are stable, use a small second backend to test them. ARM64 or RISC-V are candidates, but the purpose is to validate abstractions, not to promise immediate feature parity.
+
+---
+
+# Recommended primary references
+
+Prefer primary sources and specifications over tutorial copying:
+
+- ISO C language material and compiler documentation;
+- System V AMD64 ABI;
+- Intel or AMD architecture manuals;
+- UEFI specification;
+- Limine protocol documentation;
+- ELF specification;
+- ACPI specification;
+- Meson and Ninja documentation;
+- QEMU and GDB manuals.
+
+Secondary resources are useful for intuition, but each hardware-sensitive implementation should ultimately be checked against an authoritative specification.

--- a/docs/new-project/TESTING.md
+++ b/docs/new-project/TESTING.md
@@ -1,0 +1,139 @@
+# Testing Strategy
+
+## Goals
+
+Testing must make low-level development safer without pretending that host-side tests replace real hardware behavior.
+
+The project uses several complementary test layers:
+
+1. host-side unit tests;
+2. kernel self-tests in QEMU;
+3. boot and integration tests;
+4. debug assertions and integrity checks;
+5. manual debugger-driven validation for architecture-specific behavior.
+
+## Host-side tests
+
+Pure logic should be designed so it can be compiled and executed as a normal host program.
+
+Good candidates include:
+
+- bitmaps;
+- intrusive lists;
+- ring buffers;
+- string and memory functions;
+- formatting;
+- ELF validation;
+- TAR parsing;
+- VFS path resolution;
+- allocator metadata logic;
+- scheduler queue operations.
+
+Host tests must not silently rely on behavior unavailable in the freestanding kernel. Shared code should use small compatibility boundaries.
+
+## Kernel self-tests
+
+Kernel tests execute inside QEMU and validate code that depends on CPU state, page tables or interrupts.
+
+Initial suites:
+
+```text
+boot
+exceptions
+pmm
+vmm
+heap
+interrupts
+scheduler
+userspace
+syscalls
+elf
+```
+
+Tests should be selectable:
+
+```bash
+./tools/dev test pmm
+./tools/dev test vmm
+./tools/dev test all
+```
+
+## QEMU exit protocol
+
+The test kernel should terminate QEMU through a deterministic debug-exit device or another documented mechanism. CI must receive a meaningful success or failure status instead of parsing only human-readable output.
+
+Serial output remains available for diagnostics:
+
+```text
+[test] pmm.allocate_single_page ... PASS
+[test] pmm.reject_double_free ... PASS
+[test] pmm.reserve_kernel_range ... PASS
+[summary] 3 passed, 0 failed
+```
+
+## Fault-injection tests
+
+Expected CPU faults should be tested deliberately:
+
+- divide by zero;
+- invalid opcode;
+- general-protection fault;
+- non-present page fault;
+- write-protection fault;
+- user access to supervisor memory.
+
+A test passes only when the correct vector, error code and diagnostic behavior are observed.
+
+## Memory tests
+
+Memory-manager tests must verify more than successful allocation.
+
+Required cases include:
+
+- exhausted allocator behavior;
+- alignment;
+- reserved-region protection;
+- double-free detection;
+- overlapping mapping rejection;
+- mapping replacement policy;
+- permission enforcement;
+- TLB-visible updates;
+- cleanup after partial failure.
+
+## Debug instrumentation
+
+Debug builds may enable:
+
+- allocation poisoning;
+- red zones;
+- canaries;
+- list integrity checks;
+- page-table verification;
+- lock ownership checks;
+- verbose panic reports.
+
+These checks must be isolated behind build options and must not alter the intended external API.
+
+## Continuous integration
+
+The initial CI pipeline should include:
+
+```text
+format or style checks
+Meson configure
+Clang debug build
+Clang release build
+host unit tests
+QEMU boot smoke test
+selected kernel tests
+```
+
+A GCC compatibility build can be added after the primary Clang toolchain is stable.
+
+## Determinism
+
+Automated QEMU tests should use a fixed machine configuration, fixed memory size and explicit CPU model where practical. Tests must avoid real-time assumptions unless they are specifically testing timekeeping.
+
+## Test ownership
+
+Every milestone defines its own completion tests. A pull request that fixes a bug should add a regression test whenever the failure can be reproduced deterministically.

--- a/docs/new-project/TESTING.md
+++ b/docs/new-project/TESTING.md
@@ -1,41 +1,41 @@
-# Testing Strategy
+# Strategia di test
 
-## Goals
+## Obiettivi
 
-Testing must make low-level development safer without pretending that host-side tests replace real hardware behavior.
+I test devono rendere più sicuro lo sviluppo low-level senza fingere che i test host-side sostituiscano il comportamento reale dell’hardware.
 
-The project uses several complementary test layers:
+Il progetto usa più livelli complementari:
 
-1. host-side unit tests;
-2. kernel self-tests in QEMU;
-3. boot and integration tests;
-4. debug assertions and integrity checks;
-5. manual debugger-driven validation for architecture-specific behavior.
+1. unit test eseguiti sull’host;
+2. self-test del kernel in QEMU;
+3. test di boot e integrazione;
+4. assert e controlli d’integrità nelle build debug;
+5. validazione manuale con debugger per il comportamento specifico dell’architettura.
 
-## Host-side tests
+## Test host-side
 
-Pure logic should be designed so it can be compiled and executed as a normal host program.
+La logica pura deve essere progettata, quando possibile, per essere compilata ed eseguita come normale programma dell’host.
 
-Good candidates include:
+Candidati adatti:
 
-- bitmaps;
-- intrusive lists;
-- ring buffers;
-- string and memory functions;
-- formatting;
-- ELF validation;
-- TAR parsing;
-- VFS path resolution;
-- allocator metadata logic;
-- scheduler queue operations.
+- bitmap;
+- liste intrusive;
+- ring buffer;
+- funzioni stringa e memoria;
+- formattazione;
+- validazione ELF;
+- parsing TAR;
+- risoluzione dei percorsi VFS;
+- logica dei metadati degli allocator;
+- operazioni sulle code dello scheduler.
 
-Host tests must not silently rely on behavior unavailable in the freestanding kernel. Shared code should use small compatibility boundaries.
+I test host non devono dipendere silenziosamente da comportamenti assenti nel kernel freestanding. Il codice condiviso deve usare confini di compatibilità piccoli ed espliciti.
 
-## Kernel self-tests
+## Self-test del kernel
 
-Kernel tests execute inside QEMU and validate code that depends on CPU state, page tables or interrupts.
+I test kernel vengono eseguiti in QEMU e validano codice dipendente da stato CPU, page table o interrupt.
 
-Initial suites:
+Suite iniziali:
 
 ```text
 boot
@@ -50,7 +50,7 @@ syscalls
 elf
 ```
 
-Tests should be selectable:
+I test devono essere selezionabili:
 
 ```bash
 ./tools/dev test pmm
@@ -58,82 +58,80 @@ Tests should be selectable:
 ./tools/dev test all
 ```
 
-## QEMU exit protocol
+## Protocollo di uscita da QEMU
 
-The test kernel should terminate QEMU through a deterministic debug-exit device or another documented mechanism. CI must receive a meaningful success or failure status instead of parsing only human-readable output.
+Il kernel di test deve terminare QEMU tramite un dispositivo debug-exit deterministico o un altro meccanismo documentato. La CI deve ricevere uno stato significativo di successo o errore, non limitarsi a interpretare l’output testuale.
 
-Serial output remains available for diagnostics:
+La seriale resta disponibile per la diagnostica:
 
 ```text
 [test] pmm.allocate_single_page ... PASS
 [test] pmm.reject_double_free ... PASS
 [test] pmm.reserve_kernel_range ... PASS
-[summary] 3 passed, 0 failed
+[summary] 3 superati, 0 falliti
 ```
 
-## Fault-injection tests
+## Test con fault intenzionali
 
-Expected CPU faults should be tested deliberately:
+Devono essere verificati deliberatamente:
 
-- divide by zero;
-- invalid opcode;
+- divisione per zero;
+- opcode non valido;
 - general-protection fault;
-- non-present page fault;
-- write-protection fault;
-- user access to supervisor memory.
+- page fault su pagina non presente;
+- page fault per protezione in scrittura;
+- accesso utente a memoria supervisor.
 
-A test passes only when the correct vector, error code and diagnostic behavior are observed.
+Un test passa solo quando vengono osservati vettore, codice d’errore e comportamento diagnostico corretti.
 
-## Memory tests
+## Test della memoria
 
-Memory-manager tests must verify more than successful allocation.
+I test dei memory manager devono verificare più della semplice allocazione riuscita:
 
-Required cases include:
+- comportamento a memoria esaurita;
+- allineamento;
+- protezione delle regioni riservate;
+- rilevamento double-free;
+- rifiuto di mapping sovrapposti;
+- politica di sostituzione dei mapping;
+- applicazione dei permessi;
+- aggiornamenti visibili alla TLB;
+- pulizia dopo fallimenti parziali.
 
-- exhausted allocator behavior;
-- alignment;
-- reserved-region protection;
-- double-free detection;
-- overlapping mapping rejection;
-- mapping replacement policy;
-- permission enforcement;
-- TLB-visible updates;
-- cleanup after partial failure.
+## Strumentazione debug
 
-## Debug instrumentation
+Le build debug possono abilitare:
 
-Debug builds may enable:
+- poisoning delle allocazioni;
+- red zone;
+- canary;
+- controlli d’integrità delle liste;
+- verifica delle page table;
+- controlli di proprietà dei lock;
+- report panic dettagliati.
 
-- allocation poisoning;
-- red zones;
-- canaries;
-- list integrity checks;
-- page-table verification;
-- lock ownership checks;
-- verbose panic reports.
+Questi controlli devono essere protetti da opzioni di build e non devono cambiare l’API esterna prevista.
 
-These checks must be isolated behind build options and must not alter the intended external API.
+## Integrazione continua
 
-## Continuous integration
-
-The initial CI pipeline should include:
+La pipeline CI iniziale comprende:
 
 ```text
-format or style checks
-Meson configure
-Clang debug build
-Clang release build
-host unit tests
-QEMU boot smoke test
-selected kernel tests
+controlli di formato o stile
+configurazione Meson
+build debug Clang
+build release Clang
+unit test host
+smoke test di boot QEMU
+test kernel selezionati
 ```
 
-A GCC compatibility build can be added after the primary Clang toolchain is stable.
+Una build di compatibilità GCC può essere aggiunta dopo la stabilizzazione della toolchain Clang.
 
-## Determinism
+## Determinismo
 
-Automated QEMU tests should use a fixed machine configuration, fixed memory size and explicit CPU model where practical. Tests must avoid real-time assumptions unless they are specifically testing timekeeping.
+I test QEMU automatici devono usare configurazione macchina, quantità di RAM e modello CPU espliciti e stabili quando possibile. I test devono evitare assunzioni sul tempo reale, salvo quando verificano specificamente il timekeeping.
 
-## Test ownership
+## Proprietà dei test
 
-Every milestone defines its own completion tests. A pull request that fixes a bug should add a regression test whenever the failure can be reproduced deterministically.
+Ogni milestone definisce i propri test di completamento. Una PR che corregge un bug deve aggiungere un test di regressione quando il fallimento è riproducibile in modo deterministico.

--- a/docs/new-project/VISION.md
+++ b/docs/new-project/VISION.md
@@ -1,66 +1,66 @@
-# Vision and Goals
+# Visione e obiettivi
 
-## Project statement
+## Dichiarazione del progetto
 
-The project is a small educational operating system for x86_64, developed in public through a structured Italian YouTube series.
+Il progetto è un piccolo sistema operativo educativo per x86_64, sviluppato pubblicamente attraverso una serie YouTube strutturata in italiano.
 
-It is not intended to compete with Linux, provide daily-driver functionality or support many architectures in its early stages. Its purpose is to demonstrate how a modern operating system grows from a controlled boot environment into a kernel capable of running isolated user programs.
+Non vuole competere con Linux, diventare un sistema operativo di uso quotidiano o supportare molte architetture nelle prime fasi. Il suo scopo è mostrare come un sistema operativo moderno cresca da un ambiente di boot controllato fino a un kernel capace di eseguire programmi utente isolati.
 
-## Primary goals
+## Obiettivi principali
 
-### Technical goals
+### Obiettivi tecnici
 
-- Boot reliably through Limine on UEFI systems.
-- Provide strong diagnostics from the first milestone.
-- Implement physical and virtual memory management.
-- Handle CPU exceptions and hardware interrupts correctly.
-- Support kernel threads and preemptive scheduling.
-- Enter x86_64 user mode.
-- Provide a small and documented system-call ABI.
-- Load ELF programs from an initramfs.
-- Introduce a simple VFS and console device.
+- Avviare il sistema in modo affidabile tramite Limine su UEFI.
+- Offrire diagnostica robusta fin dalla prima milestone.
+- Implementare gestione della memoria fisica e virtuale.
+- Gestire correttamente eccezioni CPU e interrupt hardware.
+- Supportare thread kernel e scheduling preemptive.
+- Entrare nella modalità utente x86_64.
+- Definire una piccola ABI per le chiamate di sistema.
+- Caricare programmi ELF da un’initramfs.
+- Introdurre una VFS semplice e un dispositivo console.
 
-### Educational goals
+### Obiettivi didattici
 
-- Explain each component before implementing it.
-- Keep commits and pull requests aligned with individual lessons.
-- Provide start and completion tags for every episode.
-- Show debugging and failures, not only the final working code.
-- Document trade-offs and rejected alternatives.
-- Make the repository usable without watching every video.
+- Spiegare ogni componente prima di implementarlo.
+- Allineare commit e pull request alle singole lezioni.
+- Fornire tag iniziale e finale per ogni episodio.
+- Mostrare debugging e fallimenti, non solo il risultato funzionante.
+- Documentare compromessi e alternative scartate.
+- Rendere il repository utilizzabile anche senza guardare ogni video.
 
-## Non-goals for the first development cycle
+## Non-obiettivi del primo ciclo
 
-The following areas are intentionally postponed:
+Sono intenzionalmente rimandati:
 
-- symmetric multiprocessing;
-- ARM or RISC-V ports;
+- multiprocessore simmetrico;
+- porting ARM o RISC-V;
 - USB;
-- networking;
-- graphical desktop environments;
-- advanced storage drivers;
-- POSIX compatibility;
+- rete;
+- desktop grafico;
+- driver storage avanzati;
+- compatibilità POSIX;
 - self-hosting;
-- a custom filesystem;
-- a strict microkernel architecture.
+- filesystem personalizzato;
+- architettura strettamente microkernel.
 
-## Definition of success
+## Definizione di successo
 
-The first major project cycle is successful when the system can:
+Il primo grande ciclo è completato quando il sistema può:
 
-1. boot reproducibly in QEMU;
-2. report failures through serial diagnostics;
-3. manage physical and virtual memory safely;
-4. schedule multiple kernel threads;
-5. enter Ring 3;
-6. load and execute an ELF program from an initramfs;
-7. allow that program to write to the console and exit through system calls;
-8. run automated host-side and QEMU integration tests in CI.
+1. avviarsi in modo riproducibile in QEMU;
+2. riportare i fallimenti tramite diagnostica seriale;
+3. gestire in sicurezza memoria fisica e virtuale;
+4. schedulare più thread kernel;
+5. entrare in Ring 3;
+6. caricare ed eseguire un programma ELF da initramfs;
+7. permettere al programma di scrivere sulla console e terminare tramite syscall;
+8. eseguire in CI test host-side e integrazione QEMU.
 
-## Design philosophy
+## Filosofia progettuale
 
-The system should prefer simple implementations that are easy to inspect and verify. More sophisticated data structures and optimizations are introduced only when a demonstrated limitation requires them.
+Il sistema deve preferire implementazioni semplici, facili da ispezionare e verificare. Strutture dati e ottimizzazioni più sofisticate vengono introdotte solo quando un limite dimostrato le rende necessarie.
 
-A bitmap physical allocator is preferred before a buddy allocator. A simple kernel heap is preferred before a slab allocator. Single-core scheduling is preferred before SMP. UEFI is preferred before adding legacy BIOS support.
+Una bitmap è preferita a un buddy allocator nella prima fase. Un heap semplice precede lo slab allocator. Lo scheduling single-core precede SMP. UEFI precede il supporto BIOS legacy.
 
-The project values a stable development process more than rapid accumulation of features.
+Il progetto attribuisce più valore a un processo di sviluppo stabile che all’accumulo rapido di funzionalità.

--- a/docs/new-project/VISION.md
+++ b/docs/new-project/VISION.md
@@ -1,0 +1,66 @@
+# Vision and Goals
+
+## Project statement
+
+The project is a small educational operating system for x86_64, developed in public through a structured Italian YouTube series.
+
+It is not intended to compete with Linux, provide daily-driver functionality or support many architectures in its early stages. Its purpose is to demonstrate how a modern operating system grows from a controlled boot environment into a kernel capable of running isolated user programs.
+
+## Primary goals
+
+### Technical goals
+
+- Boot reliably through Limine on UEFI systems.
+- Provide strong diagnostics from the first milestone.
+- Implement physical and virtual memory management.
+- Handle CPU exceptions and hardware interrupts correctly.
+- Support kernel threads and preemptive scheduling.
+- Enter x86_64 user mode.
+- Provide a small and documented system-call ABI.
+- Load ELF programs from an initramfs.
+- Introduce a simple VFS and console device.
+
+### Educational goals
+
+- Explain each component before implementing it.
+- Keep commits and pull requests aligned with individual lessons.
+- Provide start and completion tags for every episode.
+- Show debugging and failures, not only the final working code.
+- Document trade-offs and rejected alternatives.
+- Make the repository usable without watching every video.
+
+## Non-goals for the first development cycle
+
+The following areas are intentionally postponed:
+
+- symmetric multiprocessing;
+- ARM or RISC-V ports;
+- USB;
+- networking;
+- graphical desktop environments;
+- advanced storage drivers;
+- POSIX compatibility;
+- self-hosting;
+- a custom filesystem;
+- a strict microkernel architecture.
+
+## Definition of success
+
+The first major project cycle is successful when the system can:
+
+1. boot reproducibly in QEMU;
+2. report failures through serial diagnostics;
+3. manage physical and virtual memory safely;
+4. schedule multiple kernel threads;
+5. enter Ring 3;
+6. load and execute an ELF program from an initramfs;
+7. allow that program to write to the console and exit through system calls;
+8. run automated host-side and QEMU integration tests in CI.
+
+## Design philosophy
+
+The system should prefer simple implementations that are easy to inspect and verify. More sophisticated data structures and optimizations are introduced only when a demonstrated limitation requires them.
+
+A bitmap physical allocator is preferred before a buddy allocator. A simple kernel heap is preferred before a slab allocator. Single-core scheduling is preferred before SMP. UEFI is preferred before adding legacy BIOS support.
+
+The project values a stable development process more than rapid accumulation of features.

--- a/docs/new-project/YOUTUBE_SERIES.md
+++ b/docs/new-project/YOUTUBE_SERIES.md
@@ -1,0 +1,216 @@
+# YouTube Series Plan
+
+## Series purpose
+
+The series documents the construction of a modern educational x86_64 operating system from an empty repository to the execution of user-space programs.
+
+The audience should learn both operating-system concepts and the engineering process used to build, debug and test low-level software.
+
+## Episode structure
+
+Each episode should contain:
+
+1. the problem being solved;
+2. the theory required to understand it;
+3. the design chosen for the project;
+4. implementation in small steps;
+5. at least one failure or diagnostic path;
+6. an observable result;
+7. a test;
+8. a start and completion tag.
+
+Recommended duration is flexible. Topics should not be stretched or compressed merely to match a fixed video length.
+
+## Season 0 — Foundations and build system
+
+### Episode 0 — Why build another operating system?
+
+- lessons learned from Zone OS;
+- scope and non-goals;
+- roadmap;
+- educational repository strategy.
+
+Result: project vision and initial repository.
+
+### Episode 1 — Hosted and freestanding C
+
+- what an operating system kernel is;
+- hosted versus freestanding execution;
+- why C23;
+- what the compiler does and does not provide.
+
+Result: first freestanding object file.
+
+### Episode 2 — Cross-compilation with Clang
+
+- target triples;
+- ABI assumptions;
+- compiler flags;
+- red zone and code model;
+- inspecting generated object files.
+
+Result: verified x86_64 kernel objects.
+
+### Episode 3 — Meson and Ninja
+
+- build graphs;
+- incremental compilation;
+- header dependencies;
+- debug and release profiles;
+- why Zone OS rebuilt too much.
+
+Result: fast incremental kernel build.
+
+### Episode 4 — Linking a kernel ELF
+
+- sections;
+- symbols;
+- linker script;
+- virtual and physical addresses;
+- map files and ELF inspection.
+
+Result: valid kernel ELF.
+
+### Episode 5 — Limine and UEFI image
+
+- firmware and bootloaders;
+- Limine protocol;
+- staging tree;
+- reproducible UEFI image.
+
+Result: QEMU transfers control to the kernel.
+
+### Episode 6 — QEMU, serial and GDB
+
+- serial output;
+- QEMU options;
+- GDB remote debugging;
+- breakpoints and register inspection.
+
+Result: debuggable controlled boot.
+
+## Season 1 — CPU foundations
+
+Topics:
+
+- kernel entry and boot response validation;
+- logging and panic;
+- x86_64 execution environment;
+- GDT;
+- TSS;
+- IDT;
+- CPU exception stubs;
+- interrupt frames;
+- page-fault diagnostics;
+- stack tracing.
+
+Season result: deliberate CPU faults produce reliable diagnostic reports.
+
+## Season 2 — Memory management
+
+Topics:
+
+- physical memory map;
+- page terminology;
+- reserved regions;
+- bitmap PMM;
+- x86_64 page tables;
+- high-half kernel;
+- direct map;
+- mapping APIs;
+- NX and permissions;
+- early allocator;
+- kernel heap.
+
+Season result: tested physical allocation, virtual mappings and dynamic kernel memory.
+
+## Season 3 — Interrupts and scheduling
+
+Topics:
+
+- legacy PIC and APIC concepts;
+- local APIC;
+- IOAPIC;
+- timers;
+- interrupt-safe code;
+- thread representation;
+- context switching;
+- ready queues;
+- idle thread;
+- preemption;
+- synchronization basics.
+
+Season result: multiple kernel threads run preemptively.
+
+## Season 4 — User space
+
+Topics:
+
+- privilege rings;
+- user address spaces;
+- user stacks;
+- transitions to Ring 3;
+- safe user-memory access;
+- syscall ABI;
+- `write`, `exit` and `yield`;
+- process lifecycle.
+
+Season result: a user program prints text through a syscall and exits.
+
+## Season 5 — Programs and files
+
+Topics:
+
+- initramfs;
+- TAR format;
+- ELF64 program loading;
+- virtual filesystem concepts;
+- vnode and file descriptors;
+- console device;
+- initial process;
+- simple command execution.
+
+Season result: multiple user programs are loaded from the initramfs.
+
+## Supporting material
+
+Each episode should publish:
+
+- episode notes;
+- diagrams where useful;
+- commands shown in the video;
+- references;
+- start and completion tags;
+- test instructions;
+- known limitations;
+- optional exercises.
+
+Suggested note template:
+
+```markdown
+# Episode NN — Title
+
+## Learning objectives
+## Starting point
+## Concepts
+## Implementation steps
+## Commands
+## Tests
+## Common errors
+## Exercises
+## Final state
+```
+
+## Teaching principles
+
+- Never hide a required compiler or linker flag without explaining it.
+- Distinguish hardware rules, ABI rules, compiler behavior and project conventions.
+- Explain undefined behavior when it affects kernel code.
+- Show how to inspect binaries with tools rather than treating the build as magic.
+- Prefer diagrams for stack layouts, page tables and transitions.
+- Keep old episode tags buildable whenever practical.
+- Correct mistakes publicly in documentation and follow-up notes.
+
+## Community workflow
+
+Questions and corrections should be directed to GitHub Discussions or episode-specific issues once the new repository supports them. Bugs should include the episode tag, host environment, command used and serial output.

--- a/docs/new-project/YOUTUBE_SERIES.md
+++ b/docs/new-project/YOUTUBE_SERIES.md
@@ -1,216 +1,216 @@
-# YouTube Series Plan
+# Piano della serie YouTube
 
-## Series purpose
+## Scopo della serie
 
-The series documents the construction of a modern educational x86_64 operating system from an empty repository to the execution of user-space programs.
+La serie documenta la costruzione di un sistema operativo educativo moderno x86_64, da un repository vuoto fino all’esecuzione di programmi nello spazio utente.
 
-The audience should learn both operating-system concepts and the engineering process used to build, debug and test low-level software.
+Il pubblico deve apprendere sia i concetti dei sistemi operativi sia il processo ingegneristico usato per costruire, debuggare e testare software low-level.
 
-## Episode structure
+## Struttura degli episodi
 
-Each episode should contain:
+Ogni episodio deve contenere:
 
-1. the problem being solved;
-2. the theory required to understand it;
-3. the design chosen for the project;
-4. implementation in small steps;
-5. at least one failure or diagnostic path;
-6. an observable result;
-7. a test;
-8. a start and completion tag.
+1. il problema da risolvere;
+2. la teoria necessaria;
+3. il design scelto;
+4. l’implementazione per piccoli passi;
+5. almeno un percorso di errore o diagnostica;
+6. un risultato osservabile;
+7. un test;
+8. un tag iniziale e uno finale.
 
-Recommended duration is flexible. Topics should not be stretched or compressed merely to match a fixed video length.
+La durata è flessibile. Gli argomenti non devono essere allungati o compressi solo per rispettare una durata prefissata.
 
-## Season 0 — Foundations and build system
+## Stagione 0 — Fondamenta e sistema di build
 
-### Episode 0 — Why build another operating system?
+### Episodio 0 — Perché costruire un altro sistema operativo?
 
-- lessons learned from Zone OS;
-- scope and non-goals;
+- lezioni apprese da Zone OS;
+- ambito e non-obiettivi;
 - roadmap;
-- educational repository strategy.
+- strategia didattica del repository.
 
-Result: project vision and initial repository.
+**Risultato:** visione del progetto e repository iniziale.
 
-### Episode 1 — Hosted and freestanding C
+### Episodio 1 — C hosted e freestanding
 
-- what an operating system kernel is;
-- hosted versus freestanding execution;
-- why C23;
-- what the compiler does and does not provide.
+- cos’è un kernel;
+- esecuzione hosted e freestanding;
+- perché C23;
+- cosa fornisce e cosa non fornisce il compilatore.
 
-Result: first freestanding object file.
+**Risultato:** primo object file freestanding.
 
-### Episode 2 — Cross-compilation with Clang
+### Episodio 2 — Cross-compilazione con Clang
 
-- target triples;
-- ABI assumptions;
-- compiler flags;
-- red zone and code model;
-- inspecting generated object files.
+- target triple;
+- assunzioni ABI;
+- flag del compilatore;
+- red zone e code model;
+- ispezione degli object file generati.
 
-Result: verified x86_64 kernel objects.
+**Risultato:** object file kernel x86_64 verificati.
 
-### Episode 3 — Meson and Ninja
+### Episodio 3 — Meson e Ninja
 
-- build graphs;
-- incremental compilation;
-- header dependencies;
-- debug and release profiles;
-- why Zone OS rebuilt too much.
+- grafi di build;
+- compilazione incrementale;
+- dipendenze dagli header;
+- profili debug e release;
+- perché Zone OS ricompilava troppo.
 
-Result: fast incremental kernel build.
+**Risultato:** build incrementale rapida del kernel.
 
-### Episode 4 — Linking a kernel ELF
+### Episodio 4 — Link di un kernel ELF
 
-- sections;
-- symbols;
+- sezioni;
+- simboli;
 - linker script;
-- virtual and physical addresses;
-- map files and ELF inspection.
+- indirizzi virtuali e fisici;
+- map file e ispezione ELF.
 
-Result: valid kernel ELF.
+**Risultato:** kernel ELF valido.
 
-### Episode 5 — Limine and UEFI image
+### Episodio 5 — Limine e immagine UEFI
 
-- firmware and bootloaders;
-- Limine protocol;
-- staging tree;
-- reproducible UEFI image.
+- firmware e bootloader;
+- protocollo Limine;
+- albero di staging;
+- immagine UEFI riproducibile.
 
-Result: QEMU transfers control to the kernel.
+**Risultato:** QEMU trasferisce il controllo al kernel.
 
-### Episode 6 — QEMU, serial and GDB
+### Episodio 6 — QEMU, seriale e GDB
 
-- serial output;
-- QEMU options;
-- GDB remote debugging;
-- breakpoints and register inspection.
+- output seriale;
+- opzioni QEMU;
+- debugging remoto GDB;
+- breakpoint e ispezione dei registri.
 
-Result: debuggable controlled boot.
+**Risultato:** boot controllato e debuggabile.
 
-## Season 1 — CPU foundations
+## Stagione 1 — Fondamenta della CPU
 
-Topics:
+Argomenti:
 
-- kernel entry and boot response validation;
-- logging and panic;
-- x86_64 execution environment;
+- entry point e validazione delle risposte di boot;
+- logging e panic;
+- ambiente di esecuzione x86_64;
 - GDT;
 - TSS;
 - IDT;
-- CPU exception stubs;
-- interrupt frames;
-- page-fault diagnostics;
-- stack tracing.
+- stub delle eccezioni CPU;
+- interrupt frame;
+- diagnostica dei page fault;
+- stack trace.
 
-Season result: deliberate CPU faults produce reliable diagnostic reports.
+**Risultato della stagione:** fault CPU intenzionali producono report diagnostici affidabili.
 
-## Season 2 — Memory management
+## Stagione 2 — Gestione della memoria
 
-Topics:
+Argomenti:
 
-- physical memory map;
-- page terminology;
-- reserved regions;
-- bitmap PMM;
-- x86_64 page tables;
-- high-half kernel;
+- memory map fisica;
+- terminologia delle pagine;
+- regioni riservate;
+- PMM bitmap;
+- page table x86_64;
+- kernel high-half;
 - direct map;
-- mapping APIs;
-- NX and permissions;
-- early allocator;
-- kernel heap.
+- API di mapping;
+- NX e permessi;
+- allocator iniziale;
+- heap kernel.
 
-Season result: tested physical allocation, virtual mappings and dynamic kernel memory.
+**Risultato:** allocazione fisica, mapping virtuali e memoria dinamica testati.
 
-## Season 3 — Interrupts and scheduling
+## Stagione 3 — Interrupt e scheduling
 
-Topics:
+Argomenti:
 
-- legacy PIC and APIC concepts;
-- local APIC;
+- PIC legacy e APIC;
+- Local APIC;
 - IOAPIC;
-- timers;
-- interrupt-safe code;
-- thread representation;
+- timer;
+- codice interrupt-safe;
+- rappresentazione dei thread;
 - context switching;
-- ready queues;
+- ready queue;
 - idle thread;
 - preemption;
-- synchronization basics.
+- basi della sincronizzazione.
 
-Season result: multiple kernel threads run preemptively.
+**Risultato:** più thread kernel vengono eseguiti in modo preemptive.
 
-## Season 4 — User space
+## Stagione 4 — Spazio utente
 
-Topics:
+Argomenti:
 
-- privilege rings;
-- user address spaces;
-- user stacks;
-- transitions to Ring 3;
-- safe user-memory access;
-- syscall ABI;
-- `write`, `exit` and `yield`;
-- process lifecycle.
+- livelli di privilegio;
+- address space utente;
+- stack utente;
+- transizione a Ring 3;
+- accesso sicuro alla memoria utente;
+- ABI syscall;
+- `write`, `exit` e `yield`;
+- ciclo di vita dei processi.
 
-Season result: a user program prints text through a syscall and exits.
+**Risultato:** un programma utente stampa tramite syscall e termina.
 
-## Season 5 — Programs and files
+## Stagione 5 — Programmi e file
 
-Topics:
+Argomenti:
 
 - initramfs;
-- TAR format;
-- ELF64 program loading;
-- virtual filesystem concepts;
-- vnode and file descriptors;
-- console device;
-- initial process;
-- simple command execution.
+- formato TAR;
+- caricamento ELF64;
+- concetti VFS;
+- vnode e file descriptor;
+- dispositivo console;
+- processo iniziale;
+- esecuzione semplice di comandi.
 
-Season result: multiple user programs are loaded from the initramfs.
+**Risultato:** più programmi utente vengono caricati dall’initramfs.
 
-## Supporting material
+## Materiale di supporto
 
-Each episode should publish:
+Ogni episodio deve pubblicare:
 
-- episode notes;
-- diagrams where useful;
-- commands shown in the video;
-- references;
-- start and completion tags;
-- test instructions;
-- known limitations;
-- optional exercises.
+- note;
+- diagrammi quando utili;
+- comandi mostrati nel video;
+- riferimenti;
+- tag iniziale e finale;
+- istruzioni di test;
+- limitazioni note;
+- esercizi facoltativi.
 
-Suggested note template:
+Template consigliato:
 
 ```markdown
-# Episode NN — Title
+# Episodio NN — Titolo
 
-## Learning objectives
-## Starting point
-## Concepts
-## Implementation steps
-## Commands
-## Tests
-## Common errors
-## Exercises
-## Final state
+## Obiettivi di apprendimento
+## Punto di partenza
+## Concetti
+## Passi di implementazione
+## Comandi
+## Test
+## Errori comuni
+## Esercizi
+## Stato finale
 ```
 
-## Teaching principles
+## Principi didattici
 
-- Never hide a required compiler or linker flag without explaining it.
-- Distinguish hardware rules, ABI rules, compiler behavior and project conventions.
-- Explain undefined behavior when it affects kernel code.
-- Show how to inspect binaries with tools rather than treating the build as magic.
-- Prefer diagrams for stack layouts, page tables and transitions.
-- Keep old episode tags buildable whenever practical.
-- Correct mistakes publicly in documentation and follow-up notes.
+- Non nascondere un flag del compilatore o linker senza spiegarlo.
+- Distinguere regole hardware, ABI, comportamento del compilatore e convenzioni del progetto.
+- Spiegare l’undefined behavior quando influenza il kernel.
+- Mostrare come ispezionare i binari invece di trattare la build come magia.
+- Preferire diagrammi per stack, page table e transizioni.
+- Mantenere compilabili i tag dei vecchi episodi quando praticabile.
+- Correggere pubblicamente gli errori nella documentazione e nelle note successive.
 
-## Community workflow
+## Flusso della community
 
-Questions and corrections should be directed to GitHub Discussions or episode-specific issues once the new repository supports them. Bugs should include the episode tag, host environment, command used and serial output.
+Domande e correzioni dovranno essere indirizzate alle GitHub Discussions o alle issue specifiche degli episodi quando il nuovo repository le supporterà. Le segnalazioni di bug devono includere tag dell’episodio, ambiente host, comando eseguito e output seriale.

--- a/docs/new-project/book/01-introduzione.md
+++ b/docs/new-project/book/01-introduzione.md
@@ -1,0 +1,333 @@
+# Capitolo 1 — Che cos'è un sistema operativo
+
+## Obiettivi
+
+Alla fine di questo capitolo sarai in grado di:
+
+- definire cosa è un sistema operativo;
+- distinguere tra kernel e user space;
+- comprendere il ruolo del kernel come intermediario tra hardware e software;
+- capire perché esistono diversi tipi di kernel;
+- collegare la teoria al nostro progetto concreto.
+
+---
+
+## 1. Il problema fondamentale
+
+Un computer, senza sistema operativo, è solo hardware.
+
+CPU, RAM, dischi, periferiche: tutto è presente, ma nulla è coordinato.
+
+Per esempio:
+
+```text
+Applicazione
+   │
+   ▼
+???
+   │
+   ▼
+Hardware
+```
+
+Domande fondamentali:
+
+- Come accede un programma alla memoria?
+- Come scrive su disco?
+- Come usa la CPU?
+- Come interagisce con altre applicazioni?
+
+Senza un sistema operativo, ogni programma dovrebbe:
+
+- conoscere l'hardware;
+- gestire direttamente periferiche;
+- evitare conflitti con altri programmi;
+- implementare il proprio scheduler;
+- gestire la memoria.
+
+Questo è impraticabile.
+
+---
+
+## 2. Definizione di sistema operativo
+
+Un sistema operativo è uno strato software che:
+
+- astrae l'hardware;
+- gestisce le risorse;
+- fornisce servizi ai programmi;
+- impone regole di sicurezza e isolamento.
+
+Possiamo rappresentarlo così:
+
+```text
+Applicazioni (user space)
+        │
+        ▼
+Sistema operativo
+        │
+        ▼
+Hardware
+```
+
+---
+
+## 3. Il kernel
+
+Il kernel è la parte centrale del sistema operativo.
+
+È l'unico componente che:
+
+- gira con privilegi elevati;
+- può accedere direttamente all'hardware;
+- controlla memoria, CPU e dispositivi.
+
+Nel nostro progetto:
+
+```text
+User space
+    │
+    ▼
+Kernel
+    │
+    ▼
+Hardware
+```
+
+Il kernel è responsabile di:
+
+- scheduling (chi usa la CPU);
+- gestione memoria;
+- gestione processi;
+- I/O;
+- interrupt;
+- comunicazione tra programmi.
+
+---
+
+## 4. Kernel vs user space
+
+Una distinzione fondamentale:
+
+```text
+User space (applicazioni)
+Kernel space (privilegiato)
+```
+
+Il kernel:
+
+- è protetto;
+- non può essere modificato direttamente dalle applicazioni;
+- espone API controllate.
+
+Le applicazioni comunicano con il kernel tramite:
+
+```text
+syscall
+```
+
+Esempio:
+
+```text
+Applicazione → write() → kernel → disco
+```
+
+---
+
+## 5. Tipi di kernel
+
+### Kernel monolitico
+
+Tutto gira nel kernel:
+
+```text
+Kernel
+├── scheduler
+├── memoria
+├── filesystem
+├── driver
+```
+
+Vantaggi:
+
+- veloce;
+- semplice da implementare.
+
+Svantaggi:
+
+- meno isolamento;
+- bug critici.
+
+---
+
+### Microkernel
+
+Il kernel è minimale:
+
+```text
+Kernel
+├── scheduling
+├── IPC
+└── memoria
+
+User space
+├── filesystem
+├── driver
+├── rete
+```
+
+Vantaggi:
+
+- isolamento;
+- modularità.
+
+Svantaggi:
+
+- complessità;
+- overhead IPC.
+
+---
+
+### Kernel ibrido evolutivo (nostro approccio)
+
+```text
+Fase iniziale:
+Kernel monolitico modulare
+
+Fase avanzata:
+Servizi spostabili in user space
+```
+
+Questo ci permette di:
+
+- imparare velocemente;
+- mantenere flessibilità architetturale.
+
+---
+
+## 6. Meccanismo vs policy
+
+Principio fondamentale:
+
+- Meccanismo → cosa è possibile fare
+- Policy → come viene usato
+
+Esempio:
+
+```text
+Meccanismo: allocare memoria
+Policy: quale processo la ottiene
+```
+
+Il kernel deve implementare meccanismi.
+
+---
+
+## 7. Dal concetto al codice
+
+Nel nostro progetto ogni concetto teorico diventerà:
+
+- un modulo;
+- un insieme di API;
+- una struttura dati;
+- test verificabili.
+
+Esempio:
+
+```text
+Memoria fisica → modulo PMM
+Processi → modulo process
+IPC → modulo ipc
+```
+
+---
+
+## 8. Prime API (anticipazione)
+
+Anche nel primo capitolo iniziamo a ragionare in termini concreti.
+
+Esempio di API futura:
+
+```c
+enum pmm_status pmm_alloc_page(paddr_t *out_page);
+```
+
+Domande:
+
+- Chi possiede la pagina?
+- Quando viene liberata?
+- Cosa succede se fallisce?
+
+Questo tipo di ragionamento sarà centrale in tutto il libro.
+
+---
+
+## 9. Come lo fanno gli altri OS
+
+### Linux
+
+- kernel monolitico;
+- altamente modulare;
+- driver nel kernel.
+
+### Minix
+
+- microkernel;
+- servizi in user space.
+
+### seL4
+
+- microkernel formale;
+- forte isolamento.
+
+### Windows
+
+- kernel ibrido.
+
+---
+
+## 10. Collegamento alla milestone
+
+Questo capitolo è collegato a:
+
+```text
+M0 — Setup progetto
+M1 — Boot
+```
+
+---
+
+## 11. Collegamento ai video
+
+Episodi suggeriti:
+
+1. Cos'è un sistema operativo
+2. Kernel vs user space
+3. Tipi di kernel
+4. Architettura del progetto
+
+---
+
+## 12. Esercizi
+
+1. Disegna lo stack completo di esecuzione da applicazione a hardware.
+2. Spiega perché un programma non può accedere direttamente alla memoria fisica.
+3. Confronta monolitico e microkernel.
+4. Descrivi cosa succede durante una syscall.
+
+---
+
+## 13. Domande di riepilogo
+
+- Cos'è un kernel?
+- Perché serve un sistema operativo?
+- Qual è la differenza tra meccanismo e policy?
+- Qual è il ruolo delle syscall?
+
+---
+
+## 14. Prossimo capitolo
+
+Nel prossimo capitolo vedremo:
+
+> Come un sistema operativo viene caricato: firmware, bootloader e bootstrap del kernel.

--- a/docs/new-project/book/02-boot-e-firmware.md
+++ b/docs/new-project/book/02-boot-e-firmware.md
@@ -1,0 +1,104 @@
+# Capitolo 2 — Dal firmware al primo byte del kernel
+
+> "Prima di esistere un sistema operativo deve esistere un modo per caricarlo."
+
+## Obiettivi
+
+In questo capitolo comprenderemo l'intera catena di bootstrap di un PC moderno: dall'accensione della macchina fino all'ingresso nella funzione `kernel_main()`. Non implementeremo ancora il boot, ma costruiremo il modello mentale necessario per progettare correttamente il nostro kernel.
+
+## Domanda iniziale
+
+Quando premiamo il pulsante di accensione, come fa il processore a sapere dove si trova il nostro kernel?
+
+La risposta è: **non lo sa**. Esiste una sequenza di software che prepara l'ambiente e passa il controllo al kernel.
+
+## Il percorso di avvio
+
+```text
+Power On
+   │
+   ▼
+Firmware (UEFI)
+   │
+   ▼
+Boot Manager
+   │
+   ▼
+Limine
+   │
+   ▼
+Boot Adapter
+   │
+   ▼
+boot_info
+   │
+   ▼
+kernel_main()
+```
+
+## 💡 Idea
+
+Il kernel non dovrebbe conoscere il bootloader. Deve conoscere soltanto una struttura dati stabile (`boot_info`) costruita da un adapter.
+
+## 📜 Contesto storico
+
+I primi PC usavano il BIOS, progettato in un'epoca di CPU a 16 bit. Oggi useremo UEFI perché offre servizi moderni, supporto a sistemi a 64 bit e una gestione più ricca della memoria disponibile al boot.
+
+## 🧠 Pensare come il kernel
+
+Perché non includere direttamente `limine.h` in tutto il kernel?
+
+Perché il bootloader è un dettaglio di implementazione. Se domani decidessimo di usare un altro bootloader, dovremmo modificare un solo componente: il boot adapter.
+
+## API previste
+
+```c
+struct boot_info;
+
+[[nodiscard]]
+const struct boot_info *boot_get_info(void);
+
+void boot_early_init(void);
+```
+
+Queste API rappresentano il contratto tra il codice di bootstrap e il resto del kernel.
+
+## 🛠️ Implementazione
+
+Il primo punto d'ingresso del nostro kernel sarà concettualmente:
+
+```c
+void kernel_main(const struct boot_info *boot);
+```
+
+Nessun altro modulo dovrà conoscere come tali informazioni sono state ottenute.
+
+## 🔬 Esperimento
+
+Durante i primi video utilizzeremo QEMU e GDB per osservare:
+
+- il passaggio dal firmware al bootloader;
+- il caricamento dell'immagine ELF;
+- il salto al punto di ingresso del kernel.
+
+## Errori comuni
+
+- Mescolare il codice del bootloader con quello del kernel.
+- Esporre tipi specifici di Limine nelle API pubbliche.
+- Assumere che i servizi UEFI siano disponibili dopo il bootstrap.
+
+## Evoluzione futura
+
+In seguito il boot adapter potrà essere sostituito senza modificare PMM, VMM, scheduler o altri sottosistemi. Questo è il primo esempio concreto di separazione tra dipendenze esterne e API interne.
+
+## Cosa abbiamo costruito
+
+- Un modello mentale del bootstrap.
+- La distinzione tra firmware, bootloader e kernel.
+- La motivazione del boot adapter.
+- Il primo contratto API del progetto.
+
+## Collegamenti
+
+- Milestone M1.
+- Capitolo successivo: Architettura x86_64.

--- a/docs/new-project/book/02-boot/README.md
+++ b/docs/new-project/book/02-boot/README.md
@@ -1,0 +1,28 @@
+# Capitolo 2 — Boot e Firmware
+
+Questo capitolo è organizzato in più documenti per mantenere il contenuto modulare, facilmente navigabile e incrementabile.
+
+## Indice
+
+1. 01-power-on.md
+2. 02-bios.md
+3. 03-uefi.md
+4. 04-bootloader.md
+5. 05-limine.md
+6. 06-elf.md
+7. 07-boot-adapter.md
+8. 08-boot-info.md
+9. 09-kernel-main.md
+10. 10-laboratorio.md
+11. 11-esercizi.md
+
+Ogni sezione segue la stessa struttura:
+- Obiettivi
+- Teoria
+- Diagrammi
+- Pensare come il kernel
+- API
+- Implementazione
+- Esperimenti
+- Errori comuni
+- Evoluzione futura

--- a/docs/new-project/book/README.md
+++ b/docs/new-project/book/README.md
@@ -1,0 +1,101 @@
+# Libro del progetto — Sistemi operativi dalla teoria al kernel
+
+## Scopo
+
+Questa sezione trasforma la documentazione tecnica del progetto in un percorso editoriale simile a un manuale universitario di sistemi operativi, ma collegato direttamente a un kernel reale e progressivamente eseguibile.
+
+Il libro non sostituisce roadmap, ADR e specifiche API. Le organizza in una sequenza didattica composta da:
+
+1. teoria generale dei sistemi operativi;
+2. meccanismi indipendenti dall'architettura;
+3. implementazione iniziale x86_64;
+4. API pubbliche del kernel;
+5. sorgenti commentati;
+6. esperimenti e casi di fallimento;
+7. collegamenti alle milestone e agli episodi video.
+
+## Struttura editoriale
+
+Ogni capitolo deve contenere:
+
+- obiettivi di apprendimento;
+- prerequisiti;
+- modello concettuale;
+- distinzione tra meccanismo e policy;
+- astrazione generica;
+- implementazione x86_64;
+- API esposte dal kernel;
+- sorgenti commentati;
+- invarianti e ownership;
+- errori comuni;
+- test ed esperimenti;
+- domande di riepilogo;
+- esercizi;
+- collegamento alla milestone;
+- sequenza video associata.
+
+## Parti del libro
+
+### Parte I — Fondamenti
+
+- Che cos'è un sistema operativo
+- Kernel, user space e privilegi
+- C23 freestanding
+- Toolchain, ELF e linking
+- Architettura dei calcolatori
+- Firmware, bootloader e bootstrap
+
+### Parte II — Nucleo del kernel
+
+- Diagnostica, logging e panic
+- Eccezioni e contesto di esecuzione
+- Memoria fisica
+- Memoria virtuale
+- Heap del kernel
+- Interrupt e tempo
+
+### Parte III — Esecuzione e isolamento
+
+- Thread
+- Scheduler
+- Processi
+- User mode
+- Syscall ABI
+- Handle e ownership
+- IPC e memoria condivisa
+
+### Parte IV — Servizi di sistema
+
+- Initramfs
+- ELF64 e caricamento dei programmi
+- VFS
+- File descriptor
+- Driver e device model
+- Kernel ibrido evolutivo
+- Primo servizio user space
+
+### Parte V — Evoluzione
+
+- Sincronizzazione
+- SMP
+- Storage persistente
+- Networking
+- Sicurezza e capability
+- Porting verso una seconda architettura
+
+## Relazione con gli altri documenti
+
+- `../MILESTONES_DETAILED.md`: definisce cosa deve essere completato.
+- `../API_ROADMAP.md`: elenca le firme previste delle API.
+- `../STUDY_PLAN.md`: definisce cosa studiare.
+- `../YOUTUBE_SERIES.md`: descrive la serie ad alto livello.
+- `VIDEO_CURRICULUM.md`: collega capitoli, esperimenti e video.
+- `ANNOTATED_SOURCE_GUIDE.md`: definisce come presentare i sorgenti commentati.
+- `KERNEL_API_REFERENCE_STYLE.md`: definisce il formato della documentazione API.
+- `CHAPTER_TEMPLATE.md`: modello obbligatorio per ogni nuovo capitolo.
+
+## Regola editoriale principale
+
+> Ogni concetto teorico deve terminare in un artefatto osservabile: un'API, una struttura dati, un esperimento, un test o un comportamento del kernel.
+
+Il lettore deve poter studiare il capitolo senza guardare il video, mentre il video deve poter usare il capitolo come scaletta e materiale di approfondimento.

--- a/docs/new-project/book/STYLE_GUIDE.md
+++ b/docs/new-project/book/STYLE_GUIDE.md
@@ -1,0 +1,37 @@
+# Style Guide
+
+Questa guida definisce le convenzioni editoriali dell'intero libro.
+
+## Obiettivi
+
+- Uniformità tra i capitoli.
+- Collegamento diretto tra teoria e codice.
+- Progressione dai concetti alle API e all'implementazione.
+
+## Struttura di ogni sezione
+
+1. Obiettivi
+2. Prerequisiti
+3. Teoria
+4. Diagrammi
+5. 💡 Idea
+6. 🧠 Pensare come il kernel
+7. 🛠️ Implementazione
+8. API
+9. Sorgenti commentati
+10. Esperimenti
+11. Errori comuni
+12. Evoluzione futura
+13. Riepilogo
+14. Esercizi
+
+## Convenzioni per il codice
+
+- Linguaggio: ISO C23.
+- Tutti gli esempi devono essere compilabili quando possibile.
+- Le API pubbliche sono mostrate prima dell'implementazione.
+- Ogni frammento di codice deve spiegare il "perché", non solo il "come".
+
+## Diagrammi
+
+Preferire diagrammi Mermaid per facilitarne il versionamento e la modifica.


### PR DESCRIPTION
## Summary

Adds the initial documentation package for a new operating-system project built from scratch after Zone OS.

The documents cover:

- project vision and scope;
- initial kernel architecture;
- milestone roadmap;
- Meson/Ninja build-system design;
- ISO C23 freestanding policy;
- development and pull-request workflow;
- host-side and QEMU testing strategy;
- YouTube series structure;
- initial Architecture Decision Records.

## Placement

The material is temporarily stored under `docs/new-project/` in Zone OS. The intended final destination is a separate repository once the new project name and repository are created.

## Review points

- confirm the technical scope;
- choose the new project name;
- decide whether the final documentation should remain in English, move to Italian, or be bilingual;
- create the new repository and migrate this directory.
